### PR TITLE
Add contributors link

### DIFF
--- a/source/rst/index.rst
+++ b/source/rst/index.rst
@@ -17,10 +17,9 @@ Introduction to Quantitative Economics with Python
     <div class="home-intro">
         <div class="home-detail">
             <div class="home-blurb">
-                <p>This website presents a set of lectures on quantitative economic modeling, designed and written by <a href="http://www.tomsargent.com" target="_blank">Thomas J. Sargent</a> and <a href="http://johnstachurski.net" target="_blank">John Stachurski</a>. The language instruction is <a href="https://www.python.org/">Python</a>.</p>
-                <p>This is one of a <a href="https://lectures.quantecon.org/">series of lectures</a> by <a href="https://quantecon.org/">QuantEcon</a>.</p>
+                <p>This website presents a set of lectures on quantitative economic modeling, designed and written by <a href="http://www.tomsargent.com" target="_blank">Thomas J. Sargent</a> and <a href="http://johnstachurski.net" target="_blank">John Stachurski</a>.</p>
                 <p>Last compiled: <span id="compiled_date"></span><br><a href="https://github.com/QuantEcon/
-                    lecture-python-intro/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python-intro/graphs/contributors">Contributors</a></p>
+                    lecture-python-intro/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python-intro/graphs/contributors">See all contributors</a></p>
             </div>
             <div class="web-version">
                 <a href="/index_toc.html">

--- a/source/rst/index.rst
+++ b/source/rst/index.rst
@@ -1,7 +1,7 @@
 .. _index:
 
 **********************************
-Quantitative Economics with Python
+Introduction to Quantitative Economics with Python
 **********************************
 
 .. toctree::
@@ -13,13 +13,14 @@ Quantitative Economics with Python
 .. raw:: html
 
     <div><style type="text/css">h1,.breadcrumbs{display:none;}</style></div>
-    <h1 class="sr-only" style="display:block;">Quantitative Economics with Python</h1>
+    <h1 class="sr-only" style="display:block;">Introduction to Quantitative Economics with Python</h1>
     <div class="home-intro">
         <div class="home-detail">
             <div class="home-blurb">
                 <p>This website presents a set of lectures on quantitative economic modeling, designed and written by <a href="http://www.tomsargent.com" target="_blank">Thomas J. Sargent</a> and <a href="http://johnstachurski.net" target="_blank">John Stachurski</a>. The language instruction is <a href="https://www.python.org/">Python</a>.</p>
                 <p>This is one of a <a href="https://lectures.quantecon.org/">series of lectures</a> by <a href="https://quantecon.org/">QuantEcon</a>.</p>
-                <p>Last compiled: <strong><span id="compiled_date"></span></strong> <small>(<a href="https://github.com/QuantEcon/lecture-source-py/commits/">view commits</a>)</small></p>
+                <p>Last compiled: <span id="compiled_date"></span><br><a href="https://github.com/QuantEcon/
+                    lecture-python-intro/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python-intro/graphs/contributors">Contributors</a></p>
             </div>
             <div class="web-version">
                 <a href="/index_toc.html">


### PR DESCRIPTION
- Remove bold from last compiled date
- Move "View commits" link to new line, increase font size
- Add "Contributors" link next to "View commits"
- "Contributors" links points to `https://github.com/QuantEcon/lecture-python-intro/graphs/contributors`