### PR TITLE
fixed warning - inline literal start-string without end-string

### DIFF
--- a/source/rst/complex_and_trig.rst
+++ b/source/rst/complex_and_trig.rst
@@ -483,7 +483,7 @@ We can verify the analytical as well as numerical results using
 Exercises
 -----------
 
-We invite the reader to verify analytically and with the ``sympy'' package the following two equalities:
+We invite the reader to verify analytically and with the ``sympy`` package the following two equalities:
 
 
 .. math::


### PR DESCRIPTION
Fixes #55
``sympy'' was fixed to ``sympy``