### PR TITLE
fix backrefs issue

### DIFF
--- a/source/rst/exchangeable.rst
+++ b/source/rst/exchangeable.rst
@@ -544,7 +544,7 @@ assumptions about nature's choice of distribution:
 
 
 Outcomes depend on a peculiar property of likelihood ratio processes that are discussed in 
-`this lecture<https://python-advanced.quantecon.org/additive_functionals.html>`__ 
+`this lecture <https://python-advanced.quantecon.org/additive_functionals.html>`__ 
 
 To do this, we create some Python code.
 


### PR DESCRIPTION
Fixes this issue:
- /home/ubuntu/repos/lecture-python-intro/source/rst/exchangeable.rst:: WARNING: Anonymous hyperlink mismatch: 1 references but 0 targets.
See "backrefs" attribute for IDs.