### PR TITLE
Home layout #15

### DIFF
--- a/source/rst/index.rst
+++ b/source/rst/index.rst
@@ -50,16 +50,11 @@ Introductory Quantitative Economics with Python
                     <p>Get the full set of Jupyter notebooks</p>
                 </a>
             </li>
-        </ul>
-    </div>
-    <div class="home-alternatives">
-        <h2>Open source lectures</h2>
-        <ul>
             <li>
-                <a href="https://github.com/QuantEcon/lecture-source-py">
+                <a href="https://github.com/QuantEcon/lecture-python-intro">
                     <i class="fab fa-github"></i>
                     <h3>GitHub Repository</h3>
-                    <p>The source files for these lectures are openly available and stored on GitHub.  We welcome feedback and improvements.  Readers can view the source files, report issues and submit pull requests (suggested changes).</p>
+                    <p>The source files for these lectures are openly available and stored on GitHub.  We welcome feedback and improvements.</p>
                 </a>
             </li>
         </ul>


### PR DESCRIPTION
https://github.com/QuantEcon/lecture-python-website/issues/15

"Open source lectures" heading removed and the GitHub box combined with the other two, so there are three boxes under "Other ways to...".

Please remove the sentence "Readers can view the source... changes)"