### PR TITLE
optgrowth1_attachlinks

### DIFF
--- a/source/rst/optgrowth.rst
+++ b/source/rst/optgrowth.rst
@@ -189,7 +189,7 @@ We'll be particularly interested in **Markov policies**, which are maps from the
 
 For dynamic programming problems such as this one (in fact for any `Markov decision process <https://en.wikipedia.org/wiki/Markov_decision_process>`__), the optimal policy is always a Markov policy.
 
-In other words, the current state :math:`y_t` provides a sufficient statistic
+In other words, the current state :math:`y_t` provides a `sufficient statistic <https://en.wikipedia.org/wiki/Sufficient_statistic>`__
 for the history in terms of making an optimal decision today.
 
 This is quite intuitive, but if you wish you can find proofs in texts such as :cite:`StokeyLucas1989` (section 4.1).
@@ -522,7 +522,7 @@ Scalar Maximization
 -------------------
 
 
-To maximize the right hand side of the Bellman equation, we are going to use
+To maximize the right hand side of the Bellman equation :eq:`fpb30`, we are going to use
 the ``minimize_scalar`` routine from SciPy.
 
 Since we are maximizing rather than minmizing, we will use the fact that the


### PR DESCRIPTION
Good morning @jstac , this PR
1. adds an internal link to ``equation (9)`` after the expression ``the right hand side of the Bellman equation`` [here](https://python-intro.quantecon.org/optgrowth.html#Scalar-Maximization).
2. attaches an external link (https://en.wikipedia.org/wiki/Sufficient_statistic) to clarify the ``sufficient statistic`` [here](https://python-intro.quantecon.org/optgrowth.html#The-Policy-Function-Approach).