### PR TITLE
optgrowth1_clarifyshock

### DIFF
--- a/source/rst/optgrowth.rst
+++ b/source/rst/optgrowth.rst
@@ -560,9 +560,9 @@ Optimal Growth Model
 
 We will assume for now that :math:`\phi` is the distribution of :math:`\xi := \exp(\mu + s \zeta)` where 
 
-* :math:`\zeta` is standard normal and
-* :math:`\mu` is the shock location parameter and
-* :math:`s` is the shock scale parameter.
+* :math:`\zeta` is standard normal,
+* :math:`\mu` is a shock location parameter and
+* :math:`s` is a shock scale parameter.
 
 We will store this and other primitives of the optimal growth model in a class. 
 

--- a/source/rst/optgrowth.rst
+++ b/source/rst/optgrowth.rst
@@ -557,9 +557,8 @@ in an outer function as follows:
 Optimal Growth Model
 --------------------
 
-Let :math:`\xi=\exp(\mu + s \zeta)`.
 
-We will assume for now that :math:`\phi` is the distribution of :math:`\exp(\mu + s \zeta)` where 
+We will assume for now that :math:`\phi` is the distribution of :math:`\xi := \exp(\mu + s \zeta)` where 
 
 * :math:`\zeta` is standard normal and
 * :math:`\mu` is the shock location parameter and

--- a/source/rst/optgrowth.rst
+++ b/source/rst/optgrowth.rst
@@ -557,8 +557,13 @@ in an outer function as follows:
 Optimal Growth Model
 --------------------
 
+Let :math:`\xi=\exp(\mu + s \zeta)`.
 
-We will assume for now that :math:`\phi` is the distribution of :math:`\exp(\mu + s \zeta)` when :math:`\zeta` is standard normal.
+We will assume for now that :math:`\phi` is the distribution of :math:`\exp(\mu + s \zeta)` where 
+
+* :math:`\zeta` is standard normal and
+* :math:`\mu` is the shock location parameter and
+* :math:`s` is the shock scale parameter.
 
 We will store this and other primitives of the optimal growth model in a class. 
 


### PR DESCRIPTION
Hey @jstac , this PR adds expressions
1. ``Let $\xi=\exp( \mu + s \zeta)$.``,
2. ``$\mu$ is the shock location parameter and``
3. ``$s$ is the shock scale parameter.``.

to clarify ``shock`` to be stored in the following class, please see [here](https://python-intro.quantecon.org/optgrowth.html#Optimal-Growth-Model).