### PR TITLE
optgrowth2&3_typos

### DIFF
--- a/source/rst/coleman_policy_iter.rst
+++ b/source/rst/coleman_policy_iter.rst
@@ -231,14 +231,14 @@ For any :math:`\sigma \in \mathscr P`, the right side of :eq:`cpi_coledef`
 
 * is continuous and strictly increasing in :math:`c` on :math:`(0, y)`
 
-* diverges to :math:`+\infty` as :math:`c \rightarrow y^-`
+* diverges to :math:`+\infty` as :math:`c \uparrow y`
 
 
 The left side of :eq:`cpi_coledef`
 
 * is continuous and strictly decreasing in :math:`c` on :math:`(0, y)`
 
-* diverges to :math:`+\infty` as :math:`c \leftarrow 0^+`
+* diverges to :math:`+\infty` as :math:`c \downarrow 0`
 
 
 Sketching these curves and using the information above will convince you that they cross exactly once as :math:`c` ranges over :math:`(0, y)`.

--- a/source/rst/coleman_policy_iter.rst
+++ b/source/rst/coleman_policy_iter.rst
@@ -167,9 +167,9 @@ Recall the Bellman operator
 .. math::
     :label: fcbell20_coleman
 
-    Tw(y) := \max_{0 \leq c \leq y}
+    Tv(y) := \max_{0 \leq c \leq y}
     \left\{
-        u(c) + \beta \int w(f(y - c) z) \phi(dz)
+        u(c) + \beta \int v(f(y - c) z) \phi(dz)
     \right\}
 
 
@@ -231,14 +231,14 @@ For any :math:`\sigma \in \mathscr P`, the right side of :eq:`cpi_coledef`
 
 * is continuous and strictly increasing in :math:`c` on :math:`(0, y)`
 
-* diverges to :math:`+\infty` as :math:`c \uparrow y`
+* diverges to :math:`+\infty` as :math:`c \rightarrow y^-`
 
 
 The left side of :eq:`cpi_coledef`
 
 * is continuous and strictly decreasing in :math:`c` on :math:`(0, y)`
 
-* diverges to :math:`+\infty` as :math:`c \downarrow 0`
+* diverges to :math:`+\infty` as :math:`c \leftarrow 0^+`
 
 
 Sketching these curves and using the information above will convince you that they cross exactly once as :math:`c` ranges over :math:`(0, y)`.
@@ -257,7 +257,7 @@ It is possible to prove that there is a tight relationship between iterates of
 Mathematically, the two operators are *topologically conjugate*.
 
 Loosely speaking, this means is that if iterates of one operator converge then
-so do the other, and vice versa.
+so does the other, and vice versa.
 
 Moreover, there is a sense in which they converge at the same rate, at least
 in theory.
@@ -315,7 +315,7 @@ Now we implement a method called ``euler_diff``, which returns
         β, shocks, grid = og.β, og.shocks, og.grid
         f, f_prime, u_prime = og.f, og.f_prime, og.u_prime
 
-        # First turn w into a function via interpolation
+        # First turn σ into a function via interpolation
         σ_func = lambda x: interp(grid, σ, x)
 
         # Now set up the function we need to find the root of.
@@ -327,7 +327,7 @@ The function ``euler_diff`` evaluates integrals by Monte Carlo and
 approximates functions using linear interpolation.
 
 We will use a root-finding algorithm to solve :eq:`euler_diff` for :math:`c` given
-state math:`y` and :math:`σ`, the current guess of the policy.
+state :math:`y` and :math:`σ`, the current guess of the policy.
 
 Here's the operator :math:`K`, that implements the root-finding step.
 

--- a/source/rst/optgrowth_fast.rst
+++ b/source/rst/optgrowth_fast.rst
@@ -124,7 +124,7 @@ This is where we sacrifice flexibility in order to gain more speed.
 
 
 The class includes some methods such as ``u_prime`` that we do not need now
-but will use in later lecures.
+but will use in later lectures.
 
 
 The Bellman Operator
@@ -349,7 +349,7 @@ takes.
     %%time
     v_greedy, v_solution = solve_model(og_crra)
 
-Here is a plot the resulting policy:
+Here is a plot of the resulting policy:
 
 .. code-block:: python3
 


### PR DESCRIPTION
Hi @jstac , this PR corrects typos in lectures
- [optgrowh_fast](https://python-intro.quantecon.org/optgrowth_fast.html),
- [coleman_policy_iter](https://python-intro.quantecon.org/coleman_policy_iter.html),
