### PR TITLE
optgrowth2&3&4_punctuation

### DIFF
--- a/source/rst/egm_policy_iter.rst
+++ b/source/rst/egm_policy_iter.rst
@@ -83,13 +83,13 @@ It returns a new function :math:`K \sigma`,  where :math:`(K \sigma)(y)` is the 
 Exogenous Grid
 -------------------
 
-As discussed in :doc:`the lecture on time iteration <coleman_policy_iter>`, to implement the method on a computer we need a numerical approximation.
+As discussed in :doc:`the lecture on time iteration <coleman_policy_iter>`, to implement the method on a computer, we need a numerical approximation.
 
 In particular, we represent a policy function by a set of values on a finite grid.
 
 The function itself is reconstructed from this representation when necessary, using interpolation or some other method.
 
-:doc:`Previously <coleman_policy_iter>`, to obtain a finite representation of an updated consumption policy we
+:doc:`Previously <coleman_policy_iter>`, to obtain a finite representation of an updated consumption policy, we
 
 * fixed a grid of income points :math:`\{y_i\}`
 

--- a/source/rst/optgrowth_fast.rst
+++ b/source/rst/optgrowth_fast.rst
@@ -89,7 +89,7 @@ We continue to assume that
 
 We will once again use value function iteration to solve the model.
 
-In particular, the algorithm is unchanged and the only difference is in the implementation itself.
+In particular, the algorithm is unchanged, and the only difference is in the implementation itself.
 
 As before, we will be able to compare with the true solutions
 
@@ -330,7 +330,7 @@ value function iteration, the JIT-compiled code is usually an order of magnitude
 Exercise 2
 ----------
 
-Here's our CRRA version of ``OptimalGrowthModel``
+Here's our CRRA version of ``OptimalGrowthModel``:
 
 
 .. literalinclude:: /_static/lecture_specific/optgrowth_fast/ogm_crra.py
@@ -372,7 +372,7 @@ Execution time is an order of magnitude faster.
 Exercise 3
 ----------
 
-Here's one solution 
+Here's one solution:
 
 .. code-block:: python3
 


### PR DESCRIPTION
Hi @jstac , this PR adds punctuation in lectures
- [optgrowh_fast](https://python-intro.quantecon.org/optgrowth_fast.html),
- [coleman_policy_iter](https://python-intro.quantecon.org/coleman_policy_iter.html),
- [egm_policy_iter](https://python-intro.quantecon.org/egm_policy_iter.html).