### PR TITLE
optgrowth2&3_updatelognormal

### DIFF
--- a/source/rst/coleman_policy_iter.rst
+++ b/source/rst/coleman_policy_iter.rst
@@ -277,7 +277,7 @@ As in our :doc:`previous study <optgrowth_fast>`, we continue to assume that
 
 * :math:`f(k) = k^{\alpha}`
 
-* :math:`\phi` is the distribution of :math:`\exp(\mu + s \zeta)` when :math:`\zeta` is standard normal
+* :math:`\phi` is the distribution of :math:`\xi := \exp(\mu + s \zeta)` when :math:`\zeta` is standard normal
 
 This will allow us to compare our results to the analytical solutions
 

--- a/source/rst/optgrowth_fast.rst
+++ b/source/rst/optgrowth_fast.rst
@@ -85,7 +85,7 @@ We continue to assume that
 
 * :math:`f(k) = k^{\alpha}`
 
-* :math:`\phi` is the distribution of :math:`\exp(\mu + s \zeta)` when :math:`\zeta` is standard normal
+* :math:`\phi` is the distribution of :math:`\xi := \exp(\mu + s \zeta)` when :math:`\zeta` is standard normal
 
 We will once again use value function iteration to solve the model.
 


### PR DESCRIPTION
Hi @jstac , this PR updates the lognormal shocks from ``\exp(\mu + s \zeta)`` to ``\xi := \exp(\mu + s \zeta)`` in lectures
- [optgrowh_fast](https://python-intro.quantecon.org/optgrowth_fast.html),
- [coleman_policy_iter](https://python-intro.quantecon.org/coleman_policy_iter.html).