### PR TITLE
changing name to "Quantitative Economics with Python" and changing links

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -462,16 +462,16 @@ jupyter_pdf_author = "Thomas J. Sargent and John Stachurski"
 jupyter_pdf_excludepatterns = ["404", "index", "references"]
 
 # Set urlpath for html links in documents
-jupyter_pdf_urlpath = "https://python-intro.quantecon.org/"
+jupyter_pdf_urlpath = "https://python.quantecon.org/"
 
 # make book
 jupyter_pdf_book = False
 
 # book title
-jupyter_pdf_book_title = "Introductory Quantitative Economics with Python"
+jupyter_pdf_book_title = "Quantitative Economics with Python"
 
 # pdf book name
-jupyter_pdf_book_name = "introductory_quantitative_economics_with_python"
+jupyter_pdf_book_name = "quantitative_economics_with_python"
 
 # pdf toc file
 jupyter_pdf_book_index = "index_toc"

--- a/conf.py
+++ b/conf.py
@@ -462,7 +462,7 @@ jupyter_pdf_author = "Thomas J. Sargent and John Stachurski"
 jupyter_pdf_excludepatterns = ["404", "index", "references"]
 
 # Set urlpath for html links in documents
-jupyter_pdf_urlpath = "https://python.quantecon.org/"
+jupyter_pdf_urlpath = "https://python-intro.quantecon.org/"
 
 # make book
 jupyter_pdf_book = False

--- a/source/rst/index.rst
+++ b/source/rst/index.rst
@@ -1,7 +1,7 @@
 .. _index:
 
 ***********************************************
-Introductory Quantitative Economics with Python
+Quantitative Economics with Python
 ***********************************************
 
 .. toctree::
@@ -13,12 +13,12 @@ Introductory Quantitative Economics with Python
 .. raw:: html
 
     <div><style type="text/css">h1,.breadcrumbs{display:none;}</style></div>
-    <h1 class="sr-only" style="display:block;">Introductory Quantitative Economics with Python</h1>
+    <h1 class="sr-only" style="display:block;">Quantitative Economics with Python</h1>
     <div class="home-intro">
         <div class="home-detail">
             <div class="home-blurb">
                 <p>This website presents a set of lectures on quantitative economic modeling, designed and written by <a href="http://www.tomsargent.com" target="_blank">Thomas J. Sargent</a> and <a href="http://johnstachurski.net" target="_blank">John Stachurski</a>.</p>
-                <p>Last compiled: <span id="compiled_date"></span><br><a href="https://github.com/QuantEcon/lecture-python-intro/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python-intro/graphs/contributors">See all contributors</a></p>
+                <p>Last compiled: <span id="compiled_date"></span><br><a href="https://github.com/QuantEcon/lecture-python/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python/graphs/contributors">See all contributors</a></p>
             </div>
             <div class="web-version">
                 <a href="/index_toc.html">
@@ -51,7 +51,7 @@ Introductory Quantitative Economics with Python
                 </a>
             </li>
             <li>
-                <a href="https://github.com/QuantEcon/lecture-python-intro">
+                <a href="https://github.com/QuantEcon/lecture-python">
                     <i class="fab fa-github"></i>
                     <h3>GitHub Repository</h3>
                     <p>The source files for these lectures are openly available and stored on GitHub.  We welcome feedback and improvements.</p>

--- a/source/rst/index.rst
+++ b/source/rst/index.rst
@@ -18,7 +18,7 @@ Quantitative Economics with Python
         <div class="home-detail">
             <div class="home-blurb">
                 <p>This website presents a set of lectures on quantitative economic modeling, designed and written by <a href="http://www.tomsargent.com" target="_blank">Thomas J. Sargent</a> and <a href="http://johnstachurski.net" target="_blank">John Stachurski</a>.</p>
-                <p>Last compiled: <span id="compiled_date"></span><br><a href="https://github.com/QuantEcon/lecture-python/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python/graphs/contributors">See all contributors</a></p>
+                <p>Last compiled: <span id="compiled_date"></span><br><a href="https://github.com/QuantEcon/lecture-python-intro/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python-intro/graphs/contributors">See all contributors</a></p>
             </div>
             <div class="web-version">
                 <a href="/index_toc.html">
@@ -51,7 +51,7 @@ Quantitative Economics with Python
                 </a>
             </li>
             <li>
-                <a href="https://github.com/QuantEcon/lecture-python">
+                <a href="https://github.com/QuantEcon/lecture-python-intro">
                     <i class="fab fa-github"></i>
                     <h3>GitHub Repository</h3>
                     <p>The source files for these lectures are openly available and stored on GitHub.  We welcome feedback and improvements.</p>


### PR DESCRIPTION
Hey @mmcky I have change the name to Quantitative Economics with Python as well as changed the link from `https://python-intro.quantecon.org/` to `https://python.quantecon.org/`. 

I also changed the link to the GitHub repo from `lecture-python-intro` to `lecture-python`. 
This may have been premature but I can change it back in a commit if we do not proceed with the changing of the GitHub repo.