### PR TITLE
[GitHub Actions] add nightly build to build up to date cached website folder

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,37 @@
+name: 'Build Website Cache'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build-cache:
+    name: 'Build Website'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
+      - name: Checkout QuantEcon theme
+        uses: actions/checkout@v2
+        with:
+          repository: QuantEcon/lecture-python-intro.theme
+          token: ${{ secrets.ACTIONS_PAT }}
+          path: theme/lecture-python-intro.theme
+      - name: Cache Website Build Folder
+         id: cache
+         uses: actions/cache@v1
+         with:
+           path: _build/
+           key: cache-sphinx
+      - name: Build Website files
+        shell: bash -l {0}
+        run: |
+          make website THEMEPATH=theme/lecture-python-intro.theme
+          ls _build/website/jupyter_html/*

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -28,7 +28,7 @@ jobs:
          id: cache
          uses: actions/cache@v1
          with:
-           path: _build/
+           path: _build
            key: cache-sphinx
       - name: Build Website files
         shell: bash -l {0}


### PR DESCRIPTION
**Experimental**

Still working out how to best support full `website` previews in PR's. 

Current strategy is to:

1. Use a nightly build to cache `_build` files (may need `_build/website` to prevent doctree issues)
1. Each PR can access cache items built on the `master` branch.  