### PR TITLE
[Github Actions] add nightly execution and linkchecker testing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Execution and Link Testing (Nightly)
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  coverage:
+    name: Run Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
+      - name: Run Execution Tests
+        shell: bash -l {0}
+        run: make coverage
+  linkchecker:
+    name: Run linkchecker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
+      - name: Run Linkchecker
+        shell: bash -l {0}
+        run: make linkcheck


### PR DESCRIPTION
This PR adds nightly runs of:

1. `make coverage` over all lectures for execution testing
1. `make linkchecker` over all lectures for checking links. I expect these to have `false` positives so will need to think about failures here. 

If `logs` are difficult to read -- we can also `upload` reports as artefacts. 