### PR TITLE
optgrowth_fast_proofread

### DIFF
--- a/source/rst/optgrowth_fast.rst
+++ b/source/rst/optgrowth_fast.rst
@@ -394,7 +394,7 @@ Here's one solution:
 
         og = OptimalGrowthModel(β=β, s=0.05)
 
-        v_greedy, v_solution = solve_model(og)
+        v_greedy, v_solution = solve_model(og, verbose=False)
 
         # Define an optimal policy function
         σ_func = lambda x: interp(og.grid, v_greedy, x)


### PR DESCRIPTION
Hi @jstac , This a minor change for [exercise3](https://python-intro.quantecon.org/optgrowth_fast.html#Exercise-3) solution.

Since the exercise asks learners to replicate the figure, making an output for the number of iterations might be redundant. (like the solution output below)
![Screen Shot 2020-05-02 at 11 01 13 pm](https://user-images.githubusercontent.com/44494439/80864871-f0d41480-8cc8-11ea-825e-b90c8049fba3.png)

So, I added `verbose=False` in the solution. And the output became like below.
![Screen Shot 2020-05-02 at 11 05 49 pm](https://user-images.githubusercontent.com/44494439/80864969-8c658500-8cc9-11ea-98b8-9c7f62141771.png)

