### PR TITLE
add and fixing typos in exercies for lake model

### DIFF
--- a/source/rst/lake_model.rst
+++ b/source/rst/lake_model.rst
@@ -1050,18 +1050,18 @@ Exercises
 Exercise 1
 ----------
 
-In the Lake Model, there is derived data such as $ A $ depend on primitives like :math:`\alpha`
+In the Lake Model, there is derived data such as :math:`A` which depends on primitives like :math:`\alpha`
 and :math:`\lambda`.
 
-So, when a user alters these primitives, we need derived data to updates automatically.
+So, when a user alters these primitives, we need the derived data to update automatically.
 
 (For example, if a user changes the value of :math:`b` for a given instance of the class, we would like :math:`g = b - d` to update automatically)
 
-To achieve this outcome, we used ``class`` feature above lecture in ``LakeModel``.
+To achieve this outcome in the lecture, we used the ``class`` feature to set the local variables such as ``lm = LakeModel(α = 2)``.
 
-However, we can use descriptors and decorators such as ``@property`` to have the outcome nicely.
+However, we can use descriptors and decorators such as ``@property`` to achieve the outcome nicely.
 
-Arrange ``LakeModel`` class by using descriptors and decorators such as ``@property``.
+Arrange the ``LakeModel`` class by using descriptors and decorators such as ``@property``.
 
 (If you need to refresh your understanding of how these work, consult `this lecture <https://python-programming.quantecon.org/python_advanced_features.html>`_.)
 

--- a/source/rst/lake_model.rst
+++ b/source/rst/lake_model.rst
@@ -1119,7 +1119,7 @@ Exercise 1
 
 .. code-block:: python3
 
-    class LakeModel:
+    class LakeModelModified:
         """
         Solves the lake model and computes dynamics of unemployment stocks and
         rates.
@@ -1267,7 +1267,7 @@ steady state values to ``x0``
 
 .. code-block:: python3
 
-    lm = LakeModel()
+    lm = LakeModelModified()
     x0 = lm.rate_steady_state()
     print(f"Initial Steady State: {x0}")
 
@@ -1345,7 +1345,7 @@ state
 
 .. code-block:: python3
 
-    lm = LakeModel()
+    lm = LakeModelModified()
     x0 = lm.rate_steady_state()
 
 Here are the other parameters:

--- a/source/rst/lake_model.rst
+++ b/source/rst/lake_model.rst
@@ -1057,11 +1057,17 @@ So, when a user alters these primitives, we need the derived data to update auto
 
 (For example, if a user changes the value of :math:`b` for a given instance of the class, we would like :math:`g = b - d` to update automatically)
 
-To achieve this outcome in the lecture, we used the ``class`` feature to set the local variables such as ``lm = LakeModel(α = 2)``.
+In the code above, we took care of this issue by creating new instances every time we wanted to change parameters.
 
-However, we can use descriptors and decorators such as ``@property`` to achieve the outcome nicely.
+That way the derived data is always matched to current parameter values.
 
-Arrange the ``LakeModel`` class by using descriptors and decorators such as ``@property``.
+However, we can use descriptors instead, so that derived data is updated whenever parameters are changed.
+
+This is safer and means we don't need to create a fresh instance for every new parameterization.
+
+(On the other hand, the code becomes denser, which is why we don't always use the descriptor approach in our lectures.)
+
+In this exercise, your task is to arrange the ``LakeModel`` class by using descriptors and decorators such as ``@property``.
 
 (If you need to refresh your understanding of how these work, consult `this lecture <https://python-programming.quantecon.org/python_advanced_features.html>`_.)
 

--- a/source/rst/lake_model.rst
+++ b/source/rst/lake_model.rst
@@ -1050,6 +1050,24 @@ Exercises
 Exercise 1
 ----------
 
+In the Lake Model, there is derived data such as $ A $ depend on primitives like :math:`\alpha`
+and :math:`\lambda`.
+
+So, when a user alters these primitives, we need derived data to updates automatically.
+
+(For example, if a user changes the value of :math:`b` for a given instance of the class, we would like :math:`g = b - d` to update automatically)
+
+To achieve this outcome, we used ``class`` feature above lecture in ``LakeModel``.
+
+However, we can use descriptors and decorators such as ``@property`` to have the outcome nicely.
+
+Arrange ``LakeModel`` class by using descriptors and decorators such as ``@property``.
+
+(If you need to refresh your understanding of how these work, consult `this lecture <https://python-programming.quantecon.org/python_advanced_features.html>`_.)
+
+Exercise 2
+----------
+
 Consider an economy with an initial stock  of workers :math:`N_0 = 100` at the
 steady state level of employment in the baseline parameterization
 
@@ -1073,16 +1091,16 @@ How long does the economy take to converge to its new steady state?
 
 What is the new steady state level of employment?
 
+Note: it may be easier to use the class created in exercise 1 to help with changing variables.
 
 
-
-Exercise 2
+Exercise 3
 ----------
 
 Consider an economy with an initial stock  of workers :math:`N_0 = 100` at the
 steady state level of employment in the baseline parameterization.
 
-Suppose that for 20 periods the birth rate was temporarily high (:math:`b = 0.0025`) and then returned to its original level.
+Suppose that for 20 periods the birth rate was temporarily high (:math:`b = 0.025`) and then returned to its original level.
 
 Plot the transition dynamics of the unemployment and employment stocks for 50 periods.
 
@@ -1096,17 +1114,156 @@ How long does the economy take to return to its original steady state?
 Solutions
 =========
 
-
-
-
-Lake Model Solutions
-====================
-
 Exercise 1
+----------
+
+.. code-block:: python3
+
+    class LakeModel:
+        """
+        Solves the lake model and computes dynamics of unemployment stocks and
+        rates.
+
+        Parameters:
+        ------------
+        λ : scalar
+            The job finding rate for currently unemployed workers
+        α : scalar
+            The dismissal rate for currently employed workers
+        b : scalar
+            Entry rate into the labor force
+        d : scalar
+            Exit rate from the labor force
+
+        """
+        def __init__(self, λ=0.283, α=0.013, b=0.0124, d=0.00822):
+            self._λ, self._α, self._b, self._d = λ, α, b, d
+            self.compute_derived_values()
+
+        def compute_derived_values(self):
+            # Unpack names to simplify expression
+            λ, α, b, d = self._λ, self._α, self._b, self._d
+
+            self._g = b - d
+            self._A = np.array([[(1-d) * (1-λ) + b,      (1 - d) * α + b],
+                                [        (1-d) * λ,   (1 - d) * (1 - α)]])
+
+            self._A_hat = self._A / (1 + self._g)
+
+        @property
+        def g(self):
+            return self._g
+
+        @property
+        def A(self):
+            return self._A
+
+        @property
+        def A_hat(self):
+            return self._A_hat
+
+        @property
+        def λ(self):
+            return self._λ
+
+        @λ.setter
+        def λ(self, new_value):
+            self._λ = new_value
+            self.compute_derived_values()
+
+        @property
+        def α(self):
+            return self._α
+
+        @α.setter
+        def α(self, new_value):
+            self._α = new_value
+            self.compute_derived_values()
+
+        @property
+        def b(self):
+            return self._b
+
+        @b.setter
+        def b(self, new_value):
+            self._b = new_value
+            self.compute_derived_values()
+
+        @property
+        def d(self):
+            return self._d
+
+        @d.setter
+        def d(self, new_value):
+            self._d = new_value
+            self.compute_derived_values()
+
+
+        def rate_steady_state(self, tol=1e-6):
+            """
+            Finds the steady state of the system :math:`x_{t+1} = \hat A x_{t}`
+
+            Returns
+            --------
+            xbar : steady state vector of employment and unemployment rates
+            """
+            x = 0.5 * np.ones(2)
+            error = tol + 1
+            while error > tol:
+                new_x = self.A_hat @ x
+                error = np.max(np.abs(new_x - x))
+                x = new_x
+            return x
+
+        def simulate_stock_path(self, X0, T):
+            """
+            Simulates the sequence of Employment and Unemployment stocks
+
+            Parameters
+            ------------
+            X0 : array
+                Contains initial values (E0, U0)
+            T : int
+                Number of periods to simulate
+
+            Returns
+            ---------
+            X : iterator
+                Contains sequence of employment and unemployment stocks
+            """
+
+            X = np.atleast_1d(X0)  # Recast as array just in case
+            for t in range(T):
+                yield X
+                X = self.A @ X
+
+        def simulate_rate_path(self, x0, T):
+            """
+            Simulates the sequence of employment and unemployment rates
+
+            Parameters
+            ------------
+            x0 : array
+                Contains initial values (e0,u0)
+            T : int
+                Number of periods to simulate
+
+            Returns
+            ---------
+            x : iterator
+                Contains sequence of employment and unemployment rates
+
+            """
+            x = np.atleast_1d(x0)  # Recast as array just in case
+            for t in range(T):
+                yield x
+                x = self.A_hat @ x
+
+Exercise 2
 -----------
 
 We begin by constructing the class containing the default parameters and assigning the
-steady state values to `x0`
+steady state values to ``x0``
 
 .. code-block:: python3
 
@@ -1125,7 +1282,7 @@ New legislation changes :math:`\lambda` to :math:`0.2`
 
 .. code-block:: python3
 
-    lm.lmda = 0.2
+    lm.λ = 0.2
 
     xbar = lm.rate_steady_state()  # new steady state
     X_path = np.vstack(tuple(lm.simulate_stock_path(x0 * N0, T)))
@@ -1175,7 +1332,7 @@ And how the rates evolve
 We see that it takes 20 periods for the economy to converge to its new
 steady state levels.
 
-Exercise 2
+Exercise 3
 ----------
 
 This next exercise has the economy experiencing a boom in entrances to
@@ -1195,7 +1352,7 @@ Here are the other parameters:
 
 .. code-block:: python3
 
-    b_hat = 0.003
+    b_hat = 0.025
     T_hat = 20
 
 Let's increase :math:`b` to the new value and simulate for 20 periods


### PR DESCRIPTION
Hi @jstac 

- I add an exercise which explains the issue with changing variables (why `@property` is needed)

- fix a typo with \lambda in [exercise 2](https://python-intro.quantecon.org/lake_model.html#Exercise-1) (formally exercise 1)

- fixes [typo](https://python-intro.quantecon.org/lake_model.html#Exercise-2) in exercise 3 'b=0.0025' to 'b=0.025' and in the solution code change `b=0.003` to `b=0.025`

This PR address #169 