### PR TITLE
[test] numba=0.46, interpolation=2.1.2 & rm interpolation upgrade

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - nbconvert
   - pandoc
   - pandas
-  - numba
+  - numba=0.46
   - numpy
   - matplotlib
   - networkx
@@ -19,6 +19,7 @@ dependencies:
   - statsmodels
   - seaborn
   - pip:
+    - interpolation==2.1.2
     - sphinxcontrib-jupyter
     - sphinxcontrib-bibtex
     - quantecon

--- a/source/rst/cake_eating_numerical.rst
+++ b/source/rst/cake_eating_numerical.rst
@@ -12,7 +12,7 @@ In addition to what's in Anaconda, this lecture will require the following libra
 .. code-block:: ipython
   :class: hide-output
 
-  !pip install --upgrade interpolation
+  !pip install interpolation
 
 
 
@@ -69,7 +69,7 @@ where :math:`u` is the CRRA utility function.
 The analytical solutions for the value function and optimal policy were found
 to be as follows.
 
-.. literalinclude:: /_static/lecture_specific/cake_eating_numerical/analytical.py 
+.. literalinclude:: /_static/lecture_specific/cake_eating_numerical/analytical.py
 
 
 Our first aim is to obtain these analytical solutions numerically.
@@ -78,7 +78,7 @@ Our first aim is to obtain these analytical solutions numerically.
 Value Function Iteration
 ========================
 
-The first approach we will take is **value function iteration**. 
+The first approach we will take is **value function iteration**.
 
 This is a form of **successive approximation**, and was discussed in our :doc:`lecture on job search <mccall_model>`.
 
@@ -86,7 +86,7 @@ The basic idea is:
 
 1. Take an arbitary intial guess of :math:`v`.
 
-2. Obtain an update :math:`w` defined by 
+2. Obtain an update :math:`w` defined by
 
     .. math::
         w(x) = \max_{0\leq c \leq x} \{u(c) + \beta v(x-c)\}
@@ -121,7 +121,7 @@ v` converges to the solution to the Bellman equation.
 Fitted Value Function Iteration
 -------------------------------
 
-Both consumption :math:`c` and the state variable :math:`x` are continous. 
+Both consumption :math:`c` and the state variable :math:`x` are continous.
 
 This causes complications when it comes to numerical work.
 
@@ -174,8 +174,8 @@ SciPy minimization routine into a maximization routine.
         maximizer, maximum = result.x, -result.fun
         return maximizer, maximum
 
-We'll store the parameters :math:`\beta` and :math:`\gamma` in a 
-class called ``CakeEating``. 
+We'll store the parameters :math:`\beta` and :math:`\gamma` in a
+class called ``CakeEating``.
 
 The same class will also provide a method called ``state_action_value`` that
 returns the value of a consumption choice given a particular state and guess
@@ -254,7 +254,7 @@ Let's start by creating a ``CakeEating`` instance using the default parameteriza
 Now let's see the iteration of the value function in action.
 
 We start from guess :math:`v` given by :math:`v(x) = u(x)` for every
-:math:`x` grid point. 
+:math:`x` grid point.
 
 
 .. code-block:: python3
@@ -322,7 +322,7 @@ Now let's call it, noting that it takes a little while to run.
 
     v = compute_value_function(ce)
 
-Now we can plot and see what the converged value function looks like. 
+Now we can plot and see what the converged value function looks like.
 
 .. code-block:: python3
 
@@ -376,7 +376,7 @@ consumption policy was shown to be
 
 Let's see if our numerical results lead to something similar.
 
-Our numerical strategy will be to compute 
+Our numerical strategy will be to compute
 
 .. math::
     \sigma(x) = \arg \max_{0 \leq c \leq x} \{u(c) + \beta v(x - c)\}
@@ -412,7 +412,7 @@ Now let's pass the approximate value function and compute optimal consumption:
 
 .. code-block:: python3
 
-    c = σ(ce, v)  
+    c = σ(ce, v)
 
 .. _pol_an:
 
@@ -451,7 +451,7 @@ Time Iteration
 
 Now let's look at a different strategy to compute the optimal policy.
 
-Recall that the optimal policy satisfies the Euler equation 
+Recall that the optimal policy satisfies the Euler equation
 
 .. math::
     :label: euler-cen
@@ -510,7 +510,7 @@ Exercise 1
 Try the following modification of the problem.
 
 Instead of the cake size changing according to :math:`x_{t+1} = x_t - c_t`,
-let it change according to 
+let it change according to
 
 .. math::
     x_{t+1} = (x_t - c_t)^{\alpha}
@@ -519,7 +519,7 @@ where :math:`\alpha` is a parameter satisfying :math:`0 < \alpha < 1`.
 
 (We will see this kind of update rule when we study optimal growth models.)
 
-Make the required changes to value function iteration code and plot the value and policy functions. 
+Make the required changes to value function iteration code and plot the value and policy functions.
 
 Try to reuse as much code as possible.
 
@@ -560,7 +560,7 @@ We will use `inheritance <https://en.wikipedia.org/wiki/Inheritance_(object-orie
                      x_grid_max=2.5,   # size of cake
                      x_grid_size=120):
 
-            self.α = α 
+            self.α = α
             CakeEating.__init__(self, β, γ, x_grid_min, x_grid_max, x_grid_size)
 
         def state_action_value(self, c, x, v_array):
@@ -648,7 +648,7 @@ Here's one way to implement time iteration.
             if x < 1e-12:
                 σ_new[i] = 0.0
 
-            # handle other x 
+            # handle other x
             else:
                 σ_new[i] = bisect(euler_diff, 1e-10, x - 1e-10, x)
 
@@ -687,7 +687,7 @@ Here's one way to implement time iteration.
         if verbose and i < max_iter:
             print(f"\nConverged in {i} iterations.")
 
-        return σ 
+        return σ
 
 .. code-block:: python3
 

--- a/source/rst/mccall_correlated.rst
+++ b/source/rst/mccall_correlated.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
   :class: hide-output
 
   !pip install --upgrade quantecon
-  !pip install --upgrade interpolation
+  !pip install interpolation
 
 Overview
 ========
@@ -52,15 +52,15 @@ The Model
 
 Wages at each point in time are given by
 
-.. math::     
+.. math::
 
-    w_t = \exp(z_t) + y_t 
+    w_t = \exp(z_t) + y_t
 
 where
 
-.. math::     
+.. math::
 
-    y_t \sim \exp(\mu + s \zeta_t)  
+    y_t \sim \exp(\mu + s \zeta_t)
     \quad \text{and} \quad
     z_{t+1} = d + \rho z_t + \sigma \epsilon_{t+1}
 
@@ -76,13 +76,13 @@ As before, the worker can either
 
 The value function satisfies the Bellman equation
 
-.. math::  
+.. math::
 
-    v^*(w, z) = 
-        \max 
-        \left\{ 
-            \frac{u(w)}{1-\beta}, u(c) + \beta \, \mathbb E_z v^*(w', z') 
-        \right\} 
+    v^*(w, z) =
+        \max
+        \left\{
+            \frac{u(w)}{1-\beta}, u(c) + \beta \, \mathbb E_z v^*(w', z')
+        \right\}
 
 In this express, :math:`u` is a utility function and :math:`\mathbb E_z` is expectation of next period variables given current :math:`z`.
 
@@ -96,55 +96,55 @@ There is a way that we can reduce dimensionality in this problem, which greatly 
 To start, let :math:`f^*` be the continuation value function, defined
 by
 
-.. math::  
+.. math::
 
-    f^*(z) := u(c) + \beta \, \mathbb E_z v^*(w', z') 
+    f^*(z) := u(c) + \beta \, \mathbb E_z v^*(w', z')
 
 The Bellman equation can now be written
 
-.. math::  
+.. math::
 
-    v^*(w, z) = \max \left\{ \frac{u(w)}{1-\beta}, \, f^*(z) \right\} 
+    v^*(w, z) = \max \left\{ \frac{u(w)}{1-\beta}, \, f^*(z) \right\}
 
 Combining the last two expressions, we see that the continuation value
 function satisfies
 
-.. math::     
+.. math::
 
-    f^*(z) = u(c) + \beta \, \mathbb E_z \max \left\{ \frac{u(w')}{1-\beta}, f^*(z') \right\} 
+    f^*(z) = u(c) + \beta \, \mathbb E_z \max \left\{ \frac{u(w')}{1-\beta}, f^*(z') \right\}
 
 We’ll solve this functional equation for :math:`f^*` by introducing the
 operator
 
-.. math::     
+.. math::
 
-    Qf(z) = u(c) + \beta \, \mathbb E_z \max \left\{ \frac{u(w')}{1-\beta}, f(z') \right\} 
+    Qf(z) = u(c) + \beta \, \mathbb E_z \max \left\{ \frac{u(w')}{1-\beta}, f(z') \right\}
 
 
 By construction, :math:`f^*` is a fixed point of :math:`Q`, in the sense that
 :math:`Q f^* = f^*`.
 
-Under mild assumptions, it can be shown that :math:`Q` is a `contraction mapping <https://en.wikipedia.org/wiki/Contraction_mapping>`__ over a suitable space of continuous functions on :math:`\mathbb R`. 
+Under mild assumptions, it can be shown that :math:`Q` is a `contraction mapping <https://en.wikipedia.org/wiki/Contraction_mapping>`__ over a suitable space of continuous functions on :math:`\mathbb R`.
 
 By Banach's contraction mapping theorem, this means that :math:`f^*` is the unique fixed point and we can calculate it by iterating with :math:`Q` from any reasonable initial condition.
 
 Once we have :math:`f^*`, we can solve the search problem by stopping when the reward for accepting exceeds the continuation value, or
 
-.. math::     
+.. math::
 
-    \frac{u(w)}{1-\beta} \geq f^*(z) 
+    \frac{u(w)}{1-\beta} \geq f^*(z)
 
-For utility we take :math:`u(c) = \ln(c)`. 
+For utility we take :math:`u(c) = \ln(c)`.
 
 The reservation wage is the wage where equality holds in the last expression.
 
 
 That is,
 
-.. math::     
+.. math::
     :label: corr_mcm_barw
 
-    \bar w (z) := \exp(f^*(z) (1-\beta)) 
+    \bar w (z) := \exp(f^*(z) (1-\beta))
 
 
 Our main aim is to solve for the reservation rule and study its properties and implications.
@@ -158,7 +158,7 @@ Let :math:`f` be our initial guess of :math:`f^*`.
 
 When we iterate, we use the :doc:`fitted value function iteration <mccall_fitted_vfi>` algorithm.
 
-In particular, :math:`f` and all subsequent iterates are stored as a vector of values on a grid. 
+In particular, :math:`f` and all subsequent iterates are stored as a vector of values on a grid.
 
 These points are interpolated into a function as required, using piecewise linear interpolation.
 
@@ -189,7 +189,7 @@ Default parameter values are embedded in the class.
 
     @jitclass(job_search_data)
     class JobSearch:
-    
+
         def __init__(self,
                      μ=0.0,       # transient shock log mean
                      s=1.0,       # transient shock log variance
@@ -200,36 +200,36 @@ Default parameter values are embedded in the class.
                      c=5,         # unemployment compensation
                      mc_size=1000,
                      grid_size=100):
-    
-            self.μ, self.s, self.d,  = μ, s, d, 
-            self.ρ, self.σ, self.β, self.c = ρ, σ, β, c 
-    
+
+            self.μ, self.s, self.d,  = μ, s, d,
+            self.ρ, self.σ, self.β, self.c = ρ, σ, β, c
+
             # Set up grid
             z_mean = d / (1 - ρ)
             z_sd = np.sqrt(σ / (1 - ρ**2))
             k = 3  # std devs from mean
             a, b = z_mean - k * z_sd, z_mean + k * z_sd
             self.z_grid = np.linspace(a, b, grid_size)
-    
+
             # Draw and store shocks
             np.random.seed(1234)
             self.e_draws = randn(2, mc_size)
-    
+
         def parameters(self):
             """
             Return all parameters as a tuple.
             """
             return self.μ, self.s, self.d, \
                     self.ρ, self.σ, self.β, self.c
-            
+
 Next we implement the :math:`Q` operator.
 
 .. code:: ipython3
 
     @njit(parallel=True)
-    def Q(js, f_in, f_out):       
+    def Q(js, f_in, f_out):
         """
-        Apply the operator Q.  
+        Apply the operator Q.
 
             * js is an instance of JobSearch
             * f_in and f_out are arrays that represent f and Qf respectively
@@ -245,12 +245,12 @@ Next we implement the :math:`Q` operator.
             for m in range(M):
                 e1, e2 = js.e_draws[:, m]
                 z_next = d + ρ * z + σ * e1
-                go_val = interp(js.z_grid, f_in, z_next)     # f(z') 
+                go_val = interp(js.z_grid, f_in, z_next)     # f(z')
                 y_next = np.exp(μ + s * e2)                  # y' draw
                 w_next = np.exp(z_next) + y_next             # w' draw
-                stop_val = np.log(w_next) / (1 - β)    
+                stop_val = np.log(w_next) / (1 - β)
                 expectation += max(stop_val, go_val)
-            expectation = expectation / M 
+            expectation = expectation / M
             f_out[i] = np.log(c) + β * expectation
 
 Here's a function to compute an approximation to the fixed point of :math:`Q`.
@@ -259,19 +259,19 @@ Here's a function to compute an approximation to the fixed point of :math:`Q`.
 
     def compute_fixed_point(js,
                             use_parallel=True,
-                            tol=1e-4, 
-                            max_iter=1000, 
+                            tol=1e-4,
+                            max_iter=1000,
                             verbose=True,
-                            print_skip=25): 
-    
+                            print_skip=25):
+
         f_init = np.log(js.c) * np.ones(len(js.z_grid))
         f_out = np.empty_like(f_init)
-    
+
         # Set up loop
         f_in = f_init
         i = 0
         error = tol + 1
-    
+
         while i < max_iter and error > tol:
             Q(js, f_in, f_out)
             error = np.max(np.abs(f_in - f_out))
@@ -279,13 +279,13 @@ Here's a function to compute an approximation to the fixed point of :math:`Q`.
             if verbose and i % print_skip == 0:
                 print(f"Error at iteration {i} is {error}.")
             f_in[:] = f_out
-    
-        if i == max_iter: 
+
+        if i == max_iter:
             print("Failed to converge!")
-    
+
         if verbose and i < max_iter:
             print(f"\nConverged in {i} iterations.")
-    
+
         return f_out
 
 Let's try generating an instance and solving the model.
@@ -304,7 +304,7 @@ Next we will compute and plot the reservation wage function defined in :eq:`corr
 .. code:: ipython3
 
     res_wage_function = np.exp(f_star * (1 - js.β))
-    
+
     fig, ax = plt.subplots()
     ax.plot(js.z_grid, res_wage_function, label="reservation wage given $z$")
     ax.set(xlabel="$z$", ylabel="wage")
@@ -322,15 +322,15 @@ reservation wage:
 .. code:: ipython3
 
     c_vals = 1, 2, 3
-    
+
     fig, ax = plt.subplots()
-    
+
     for c in c_vals:
         js = JobSearch(c=c)
         f_star = compute_fixed_point(js, verbose=False)
         res_wage_function = np.exp(f_star * (1 - js.β))
         ax.plot(js.z_grid, res_wage_function, label=f"$\\bar w$ at $c = {c}$")
-        
+
     ax.set(xlabel="$z$", ylabel="wage")
     ax.legend()
     plt.show()
@@ -349,21 +349,21 @@ For simplicity we’ll fix the initial state at :math:`z_t = 0`.
 .. code:: ipython3
 
     def compute_unemployment_duration(js, seed=1234):
-        
+
         f_star = compute_fixed_point(js, verbose=False)
         μ, s, d, ρ, σ, β, c = js.parameters()
         z_grid = js.z_grid
         np.random.seed(seed)
-            
+
         @njit
         def f_star_function(z):
             return interp(z_grid, f_star, z)
-    
+
         @njit
         def draw_tau(t_max=10_000):
             z = 0
             t = 0
-    
+
             unemployed = True
             while unemployed and t < t_max:
                 # draw current wage
@@ -374,21 +374,21 @@ For simplicity we’ll fix the initial state at :math:`z_t = 0`.
                 if w >= res_wage:
                     unemployed = False
                     τ = t
-                # else increment data and state 
+                # else increment data and state
                 else:
                     z = ρ * z + d + σ * np.random.randn()
                     t += 1
             return τ
-    
+
         @njit(parallel=True)
         def compute_expected_tau(num_reps=100_000):
             sum_value = 0
             for i in prange(num_reps):
                 sum_value += draw_tau()
             return sum_value / num_reps
-    
+
         return compute_expected_tau()
-            
+
 
 Let's test this out with some possible values for unemployment compensation.
 
@@ -400,8 +400,8 @@ Let's test this out with some possible values for unemployment compensation.
         js = JobSearch(c=c)
         τ = compute_unemployment_duration(js)
         durations[i] = τ
-        
-Here is a plot of the results.        
+
+Here is a plot of the results.
 
 .. code:: ipython3
 
@@ -424,9 +424,9 @@ Exercises
 Exercise 1
 ----------
 
-Investigate how mean unemployment duration varies with the discount factor :math:`\beta`. 
+Investigate how mean unemployment duration varies with the discount factor :math:`\beta`.
 
-* What is your prior expectation? 
+* What is your prior expectation?
 
 * Do your results match up?
 
@@ -448,8 +448,8 @@ Here is one solution.
         js = JobSearch(β=β)
         τ = compute_unemployment_duration(js)
         durations[i] = τ
-        
-        
+
+
 
 .. code:: ipython3
 

--- a/source/rst/mccall_fitted_vfi.rst
+++ b/source/rst/mccall_fitted_vfi.rst
@@ -16,7 +16,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
   :class: hide-output
 
   !pip install --upgrade quantecon
-  !pip install --upgrade interpolation
+  !pip install interpolation
 
 
 Overview
@@ -25,7 +25,7 @@ Overview
 In this lecture we again study the :doc:`McCall job search model with separation <mccall_model_with_separation>`, but now with a continuous wage distribution.
 
 While we already considered continuous wage distributions briefly in the
-exercises of the :doc:`first job search lecture <mccall_model>`, 
+exercises of the :doc:`first job search lecture <mccall_model>`,
 the change was relatively trivial in that case.
 
 This is because we were able to reduce the problem to solving for a single
@@ -77,9 +77,9 @@ and
 .. math::
     :label: bell2mcmc
 
-    v(w) = u(w) + \beta 
+    v(w) = u(w) + \beta
         \left[
-            (1-\alpha)v(w) + \alpha d  
+            (1-\alpha)v(w) + \alpha d
         \right]
 
 The unknowns here are the function :math:`v` and the scalar :math:`d`.
@@ -114,7 +114,7 @@ The iterates of the value function can neither be calculated exactly nor stored 
 
 To see the issue, consider :eq:`bell2mcmc`.
 
-Even if :math:`v` is a known function,  the only way to store its update :math:`v'` 
+Even if :math:`v` is a known function,  the only way to store its update :math:`v'`
 is to record its value :math:`v'(w)` for every :math:`w \in \mathbb R_+`.
 
 Clearly, this is impossible.
@@ -154,7 +154,7 @@ produce a good approximation to each :math:`v`, but also that it combines well w
 
 One good choice from both respects is continuous piecewise linear interpolation.
 
-This method 
+This method
 
 1. combines well with value function iteration (see., e.g.,
    :cite:`gordon1995stable` or :cite:`stachurski2008continuous`) and
@@ -233,10 +233,10 @@ Here's our class.
     @jitclass(mccall_data_continuous)
     class McCallModelContinuous:
 
-        def __init__(self, 
-                     c=1, 
-                     α=0.1, 
-                     β=0.96, 
+        def __init__(self,
+                     c=1,
+                     α=0.1,
+                     β=0.96,
                      grid_min=1e-10,
                      grid_max=5,
                      grid_size=100,
@@ -250,10 +250,10 @@ Here's our class.
         def update(self, v, d):
 
             # Simplify names
-            c, α, β, σ, μ = self.c, self.α, self.β, self.σ, self.μ 
+            c, α, β, σ, μ = self.c, self.α, self.β, self.σ, self.μ
             w = self.w_grid
             u = lambda x: np.log(x)
-            
+
             # Interpolate array represented value function
             vf = lambda x: interp(w, v, x)
 
@@ -338,7 +338,7 @@ Exercise 1
 ----------
 
 Use the code above to explore what happens to the reservation wage when the wage parameter :math:`\mu`
-changes. 
+changes.
 
 Use the default parameters and :math:`\mu` in ``mu_vals = np.linspace(0.0, 2.0, 15)``
 
@@ -360,7 +360,7 @@ support.
 
 Use ``s_vals = np.linspace(1.0, 2.0, 15)`` and ``m = 2.0``.
 
-State how you expect the reservation wage vary with :math:`s`.  
+State how you expect the reservation wage vary with :math:`s`.
 
 Now compute it.  Is this as you expected?
 
@@ -381,7 +381,7 @@ Here is one solution.
     w_bar_vals = np.empty_like(mu_vals)
 
     fig, ax = plt.subplots()
-    
+
     for i, m in enumerate(mu_vals):
         mcm.w_draws = lognormal_draws(μ=m)
         w_bar = compute_reservation_wage(mcm)
@@ -409,7 +409,7 @@ Here is one solution.
     w_bar_vals = np.empty_like(s_vals)
 
     fig, ax = plt.subplots()
-    
+
     for i, s in enumerate(s_vals):
         a, b = m - s, m + s
         mcm.w_draws = np.random.uniform(low=a, high=b, size=10_000)

--- a/source/rst/optgrowth_fast.rst
+++ b/source/rst/optgrowth_fast.rst
@@ -17,7 +17,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
   :class: hide-output
 
   !pip install --upgrade quantecon
-  !pip install --upgrade interpolation
+  !pip install interpolation
 
 Overview
 ========
@@ -35,12 +35,12 @@ speed.
 The reason is that, when code is less flexible, we can exploit structure more
 easily.
 
-(This is true about algorithms and mathematical problems more generally: 
+(This is true about algorithms and mathematical problems more generally:
 more specific problems have more structure, which, with some thought, can be
 exploited for better results.)
 
 So, in this lecture, we are going to accept less flexibility while gaining
-speed, using just-in-time (JIT) compilation to 
+speed, using just-in-time (JIT) compilation to
 accelerate our code.
 
 Let's start with some imports:
@@ -173,11 +173,11 @@ of the Bellman equation:
 
         for i in range(len(og.grid)):
             y = og.grid[i]
-           
+
             # Maximize RHS of Bellman equation at state y
             result = brent_max(state_action_value, 1e-10, y, args=(y, v, og))
             v_greedy[i], v_new[i] = result[0], result[1]
-           
+
         return v_greedy, v_new
 
 We use the ``solve_model`` function to perform iteration until convergence.
@@ -309,7 +309,7 @@ Let's set up the initial condition.
 
 .. code-block:: ipython3
 
-    v = og.u(og.grid)  
+    v = og.u(og.grid)
 
 Here's the timing:
 


### PR DESCRIPTION
This PR removes `--upgrade` from `pip install --upgrade interpolation` which were being executed under these lectures:

- cake_eating_numerical.rst
- mccall_correlated.rst
- mccall_fitted_vfi.rst
- optgrowth_fast.rst

The numba and interpolation versions pre-coverage:
```
# Name                    Version                   Build  Channel
numba                     0.46.0           py37h4f17bb1_1    conda-forge
# Name                    Version                   Build  Channel
interpolation             2.1.2                    pypi_0    pypi
```
The numba and interpolation versions post-coverage:
```
# Name                    Version                   Build  Channel
numba                     0.46.0           py37h4f17bb1_1    conda-forge
# Name                    Version                   Build  Channel
interpolation             2.1.2                    pypi_0    pypi
```
All lectures execute successfully :tada:.