### PR TITLE
[environment] remove pinned version of numba to reflect latest Anaconda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - nbconvert
   - pandoc
   - pandas
-  - numba=0.46
+  - numba
   - numpy
   - matplotlib
   - networkx

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - statsmodels
   - seaborn
   - pip:
-    - interpolation==2.1.2
+    - interpolation
     - sphinxcontrib-jupyter
     - sphinxcontrib-bibtex
     - quantecon


### PR DESCRIPTION
This PR will remove the `numba=0.46` pinned version in `enviroment.yml` so that we tests againts the latest `numba` release in anaconda