### PR TITLE
[INFRA] migrate from lecture-python-intro to lecture-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# lecture-python-intro
-Source files for https://python-intro.quantecon.org
+# lecture-python
+
+Source files for https://python.quantecon.org

--- a/conf.py
+++ b/conf.py
@@ -464,7 +464,7 @@ jupyter_pdf_author = "Thomas J. Sargent and John Stachurski"
 jupyter_pdf_excludepatterns = ["404", "index", "references"]
 
 # Set urlpath for html links in documents
-jupyter_pdf_urlpath = "https://python-intro.quantecon.org/"
+jupyter_pdf_urlpath = "https://python.quantecon.org/"
 
 # make book
 jupyter_pdf_book = False

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,462 +8,462 @@
 
 
 <url>
-  <loc>https://python-intro.quantecon.org/</loc>
+  <loc>https://python.quantecon.org/</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_toc.html</loc>
+  <loc>https://python.quantecon.org/index_toc.html</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/introductory_quantitative_economics_with_python.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/introductory_quantitative_economics_with_python.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/about_lectures.html</loc>
+  <loc>https://python.quantecon.org/about_lectures.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_tools_and_techniques.html</loc>
+  <loc>https://python.quantecon.org/index_tools_and_techniques.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/geom_series.html</loc>
+  <loc>https://python.quantecon.org/geom_series.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/linear_algebra.html</loc>
+  <loc>https://python.quantecon.org/linear_algebra.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/complex_and_trig.html</loc>
+  <loc>https://python.quantecon.org/complex_and_trig.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/lln_clt.html</loc>
+  <loc>https://python.quantecon.org/lln_clt.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/heavy_tails.html</loc>
+  <loc>https://python.quantecon.org/heavy_tails.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_intro_dynam.html</loc>
+  <loc>https://python.quantecon.org/index_intro_dynam.html</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/scalar_dynam.html</loc>
+  <loc>https://python.quantecon.org/scalar_dynam.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/ar1_processes.html</loc>
+  <loc>https://python.quantecon.org/ar1_processes.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/finite_markov.html</loc>
+  <loc>https://python.quantecon.org/finite_markov.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/inventory_dynamics.html</loc>
+  <loc>https://python.quantecon.org/inventory_dynamics.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/linear_models.html</loc>
+  <loc>https://python.quantecon.org/linear_models.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/samuelson.html</loc>
+  <loc>https://python.quantecon.org/samuelson.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/kesten_processes.html</loc>
+  <loc>https://python.quantecon.org/kesten_processes.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/wealth_dynamics.html</loc>
+  <loc>https://python.quantecon.org/wealth_dynamics.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/kalman.html</loc>
+  <loc>https://python.quantecon.org/kalman.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_dynamic_programming.html</loc>
+  <loc>https://python.quantecon.org/index_dynamic_programming.html</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/short_path.html</loc>
+  <loc>https://python.quantecon.org/short_path.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/mccall_model.html</loc>
+  <loc>https://python.quantecon.org/mccall_model.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/mccall_model_with_separation.html</loc>
+  <loc>https://python.quantecon.org/mccall_model_with_separation.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/mccall_fitted_vfi.html</loc>
+  <loc>https://python.quantecon.org/mccall_fitted_vfi.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/mccall_correlated.html</loc>
+  <loc>https://python.quantecon.org/mccall_correlated.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/exchangeable.html</loc>
+  <loc>https://python.quantecon.org/exchangeable.html</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/likelihood_ratio_process.html</loc>
+  <loc>https://python.quantecon.org/likelihood_ratio_process.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_lq_control.html</loc>
+  <loc>https://python.quantecon.org/index_lq_control.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/lqcontrol.html</loc>
+  <loc>https://python.quantecon.org/lqcontrol.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/perm_income.html</loc>
+  <loc>https://python.quantecon.org/perm_income.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/perm_income_cons.html</loc>
+  <loc>https://python.quantecon.org/perm_income_cons.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/lq_inventories.html</loc>
+  <loc>https://python.quantecon.org/lq_inventories.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_data_and_empirics.html</loc>
+  <loc>https://python.quantecon.org/index_data_and_empirics.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/pandas_panel.html</loc>
+  <loc>https://python.quantecon.org/pandas_panel.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/ols.html</loc>
+  <loc>https://python.quantecon.org/ols.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/mle.html</loc>
+  <loc>https://python.quantecon.org/mle.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_multi_agent_models.html</loc>
+  <loc>https://python.quantecon.org/index_multi_agent_models.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/schelling.html</loc>
+  <loc>https://python.quantecon.org/schelling.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/lake_model.html</loc>
+  <loc>https://python.quantecon.org/lake_model.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/rational_expectations.html</loc>
+  <loc>https://python.quantecon.org/rational_expectations.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/re_with_feedback.html</loc>
+  <loc>https://python.quantecon.org/re_with_feedback.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/markov_perf.html</loc>
+  <loc>https://python.quantecon.org/markov_perf.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/uncertainty_traps.html</loc>
+  <loc>https://python.quantecon.org/uncertainty_traps.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/aiyagari.html</loc>
+  <loc>https://python.quantecon.org/aiyagari.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/index_asset_pricing.html</loc>
+  <loc>https://python.quantecon.org/index_asset_pricing.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/markov_asset.html</loc>
+  <loc>https://python.quantecon.org/markov_asset.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/harrison_kreps.html</loc>
+  <loc>https://python.quantecon.org/harrison_kreps.html</loc>
   <lastmod>2020-03-26T11:23:50+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/zreferences.html</loc>
+  <loc>https://python.quantecon.org/zreferences.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.64</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/about_lectures.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/about_lectures.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/troubleshooting.html</loc>
+  <loc>https://python.quantecon.org/troubleshooting.html</loc>
   <lastmod>2020-03-26T11:23:51+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/geom_series.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/geom_series.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/linear_algebra.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/linear_algebra.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_static/lecture_specific/linear_algebra/course_notes.pdf</loc>
+  <loc>https://python.quantecon.org/_static/lecture_specific/linear_algebra/course_notes.pdf</loc>
   <lastmod>2020-03-24T23:06:25+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/complex_and_trig.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/complex_and_trig.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/lln_clt.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/lln_clt.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/heavy_tails.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/heavy_tails.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/scalar_dynam.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/scalar_dynam.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/ar1_processes.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/ar1_processes.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/finite_markov.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/finite_markov.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/inventory_dynamics.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/inventory_dynamics.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/linear_models.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/linear_models.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_static/lecture_specific/linear_models/iteration_notes.pdf</loc>
+  <loc>https://python.quantecon.org/_static/lecture_specific/linear_models/iteration_notes.pdf</loc>
   <lastmod>2020-03-24T23:06:25+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/samuelson.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/samuelson.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/kesten_processes.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/kesten_processes.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/wealth_dynamics.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/wealth_dynamics.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/kalman.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/kalman.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/short_path.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/short_path.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/mccall_model.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/mccall_model.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/mccall_model_with_separation.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/mccall_model_with_separation.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/mccall_fitted_vfi.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/mccall_fitted_vfi.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/mccall_correlated.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/mccall_correlated.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/exchangeable.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/exchangeable.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/likelihood_ratio_process.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/likelihood_ratio_process.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/lqcontrol.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/lqcontrol.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/perm_income.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/perm_income.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/perm_income_cons.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/perm_income_cons.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/lq_inventories.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/lq_inventories.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/pandas_panel.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/pandas_panel.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/ols.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/ols.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/mle.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/mle.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/schelling.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/schelling.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/lake_model.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/lake_model.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/rational_expectations.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/rational_expectations.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/re_with_feedback.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/re_with_feedback.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/markov_perf.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/markov_perf.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/uncertainty_traps.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/uncertainty_traps.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/aiyagari.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/aiyagari.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_static/lecture_specific/aiyagari/aiyagari_obit.pdf</loc>
+  <loc>https://python.quantecon.org/_static/lecture_specific/aiyagari/aiyagari_obit.pdf</loc>
   <lastmod>2020-03-24T23:06:25+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/markov_asset.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/markov_asset.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/harrison_kreps.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/harrison_kreps.pdf</loc>
   <lastmod>2020-03-26T23:55:05+00:00</lastmod>
   <priority>0.51</priority>
 </url>
 <url>
-  <loc>https://python-intro.quantecon.org/_downloads/pdf/troubleshooting.pdf</loc>
+  <loc>https://python.quantecon.org/_downloads/pdf/troubleshooting.pdf</loc>
   <lastmod>2020-03-26T23:55:06+00:00</lastmod>
   <priority>0.41</priority>
 </url>

--- a/source/rst/index.rst
+++ b/source/rst/index.rst
@@ -19,8 +19,8 @@ Quantitative Economics with Python
             <div class="home-blurb">
                 <p>This website presents a set of lectures on quantitative economic modeling, designed and written by <a href="http://www.tomsargent.com" target="_blank">Thomas J. Sargent</a> and <a href="http://johnstachurski.net" target="_blank">John Stachurski</a>.</p>
                 <p>Last compiled: <span id="compiled_date"></span><br>
-                    <a href="https://github.com/QuantEcon/lecture-python-intro">View source</a> | 
-                    <a href="https://github.com/QuantEcon/lecture-python-intro/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python-intro/graphs/contributors">See all contributors</a></p>
+                    <a href="https://github.com/QuantEcon/lecture-python">View source</a> | 
+                    <a href="https://github.com/QuantEcon/lecture-python/commits/">View commits</a> | <a href="https://github.com/QuantEcon/lecture-python/graphs/contributors">See all contributors</a></p>
             </div>
             <div class="web-version">
                 <a href="/index_toc.html">
@@ -46,7 +46,7 @@ Quantitative Economics with Python
 				</a>
 			</li>
             <li>
-                <a href="https://github.com/QuantEcon/lecture-python-intro.notebooks">
+                <a href="https://github.com/QuantEcon/lecture-python.notebooks">
                     <i class="fas fa-file-download"></i>
                     <h3>Notebooks</h3>
                     <p>Get the full set of Jupyter notebooks</p>

--- a/source/rst/odu.rst
+++ b/source/rst/odu.rst
@@ -22,10 +22,10 @@ In addition to what’s in Anaconda, this lecture deploys the libraries:
 Overview
 --------
 
-In this lecture, we consider an extension of the `previously studied <https://python-intro.quantecon.org/mccall_model.html>`__ job search model of McCall
+In this lecture, we consider an extension of the `previously studied <https://python.quantecon.org/mccall_model.html>`__ job search model of McCall
 :cite:`McCall1970`.
 
-We'll build on a model of Bayesian learning discussed in `this lecture <https://python-intro.quantecon.org/exchangeable.html>`__ on the topic of exchangeability and its relationship to
+We'll build on a model of Bayesian learning discussed in `this lecture <https://python.quantecon.org/exchangeable.html>`__ on the topic of exchangeability and its relationship to
 the concept of IID (identically and independently distributed) random variables and to  Bayesian updating. 
 
 In the McCall model, an unemployed worker decides when to accept a
@@ -834,7 +834,7 @@ In this appendix we provide more details about how Bayes' Law contributes to the
 
 We present some graphs that bring out additional insights about how learning works.
 
-We build on graphs proposed in `this lecture <https://python-intro.quantecon.org/exchangeable.html>`__. 
+We build on graphs proposed in `this lecture <https://python.quantecon.org/exchangeable.html>`__. 
 
 In particular, we'll add actions of  our searching worker to a key graph 
 presented in that lecture.
@@ -1048,7 +1048,7 @@ In the graphs below, the red arrows in the upper right figure show how :math:`\p
 new information :math:`w_t`. 
 
 
-Recall the following formula from `this lecture <https://python-intro.quantecon.org/exchangeable.html>`__
+Recall the following formula from `this lecture <https://python.quantecon.org/exchangeable.html>`__
 
 
 .. math::

--- a/source/rst/rational_expectations.rst
+++ b/source/rst/rational_expectations.rst
@@ -695,7 +695,7 @@ Exercise 1
 ----------
 
 To map a problem into a `discounted optimal linear control
-problem <https://python-intro.quantecon.org/lqcontrol.html>`__, we need to define
+problem <https://python.quantecon.org/lqcontrol.html>`__, we need to define
 
 -  state vector :math:`x_t` and control vector :math:`u_t`
 

--- a/source/rst/samuelson.rst
+++ b/source/rst/samuelson.rst
@@ -377,7 +377,7 @@ We use the Samuelson multiplier-accelerator model as a vehicle for teaching how 
 
 We want to have a method in the class that automatically generates a simulation, either non-stochastic (:math:`\sigma=0`) or stochastic (:math:`\sigma > 0`).
 
-We also show how to map the Samuelson model into a simple instance of the ``LinearStateSpace`` class described `here <https://python-intro.quantecon.org/linear_models.html>`__.
+We also show how to map the Samuelson model into a simple instance of the ``LinearStateSpace`` class described `here <https://python.quantecon.org/linear_models.html>`__.
 
 We can use a ``LinearStateSpace`` instance to do various things that we did above with our homemade function and class.
 

--- a/source/rst/troubleshooting.rst
+++ b/source/rst/troubleshooting.rst
@@ -54,7 +54,7 @@ Reporting an Issue
 ===================
 
 One way to give feedback is to raise an issue through our `issue tracker 
-<https://github.com/QuantEcon/lecture-python-intro/issues>`__.
+<https://github.com/QuantEcon/lecture-python/issues>`__.
 
 Please be as specific as possible.  Tell us where the problem is and as much
 detail about your local set up as you can provide.

--- a/source/rst/wald_friedman.rst
+++ b/source/rst/wald_friedman.rst
@@ -140,7 +140,7 @@ random variables is also independently and identically distributed (IID).
 
 But the observer does not know which of the two distributions generated the sequence.
 
-For reasons explained  `Exchangeability and Bayesian Updating <https://python-intro.quantecon.org/exchangeable.html>`__, this means that the sequence is not
+For reasons explained  `Exchangeability and Bayesian Updating <https://python.quantecon.org/exchangeable.html>`__, this means that the sequence is not
 IID and that the observer has something to learn, even though he knows both :math:`f_0` and :math:`f_1`.
 
 After a number of draws, also to be determined, he makes a decision about
@@ -1012,7 +1012,7 @@ Here is how Wald introduces the notion of a sequential test
 .. rubric:: Footnotes
 
 .. [#f1] The decision maker acts as if he believes that the sequence of random variables
-    :math:`[z_{0}, z_{1}, \ldots]` is *exchangeable*.  See `Exchangeability and Bayesian Updating <https://python-intro.quantecon.org/exchangeable.html>`__ and
+    :math:`[z_{0}, z_{1}, \ldots]` is *exchangeable*.  See `Exchangeability and Bayesian Updating <https://python.quantecon.org/exchangeable.html>`__ and
     :cite:`Kreps88` chapter 11, for  discussions of exchangeability.
 
 Sequels


### PR DESCRIPTION
This PR updates internal links and configuration for the repository to be hosted at

https://github.com/QuantEcon/lecture-python

This is part of https://github.com/QuantEcon/meta/issues/2