### PR TITLE
[Github Actions] add framework files to compile PDF

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install Fonts
+        run: |
+          sudo apt-get install -y fonts-liberation
+          sudo apt-get install -y fonts-cmu
       - name: TexLive Cache
         id: cache
         uses: actions/cache@v1

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -22,6 +22,7 @@ jobs:
           bash scripts/install_latex.sh
           echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> ~/.bash_profile
           source ~/.bash_profile
+          ls /tmp/texlive/
       - name: Setup Anaconda
         uses: goanpeca/setup-miniconda@v1
         with:
@@ -33,7 +34,9 @@ jobs:
           activate-environment: qe-lectures
       - name: Build PDF
         shell: bash -l {0}
-        run: make pdf
+        run: |
+          ls /tmp/texlive/bin/x86_64-linux/
+          make pdf
       - uses: actions/upload-artifact@v2
         with:
           name: pdf

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,0 +1,40 @@
+name: Build PDF
+on:
+  push:
+    branch:
+      - master
+jobs:
+  pdf:
+    name: Build PDF
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
+      - name: TexLive Cache
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/texlive
+          key: cache-texlive
+      - name: Install & Update TexLive
+        shell: bash -l {0}
+        run: |
+          bash scripts/install_latex.sh
+          # echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> $BASH_ENV
+          # source /home/circleci/.bashrc
+      - name: Build PDF
+        shell: bash -l {0}
+        run: make pdf
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pdf
+          path: _build/jupyterpdf/quantitative_economics_with_python.pdf

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -22,7 +22,7 @@ jobs:
           bash scripts/install_latex.sh
           echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> ~/.bash_profile
           source ~/.bash_profile
-          ls /tmp/texlive/
+          xelatex --version
       - name: Setup Anaconda
         uses: goanpeca/setup-miniconda@v1
         with:
@@ -35,7 +35,10 @@ jobs:
       - name: Build PDF
         shell: bash -l {0}
         run: |
-          ls /tmp/texlive/bin/x86_64-linux/
+          more ~/.bash_profile
+          echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> ~/.bash_profile
+          source ~/.bash_profile
+          more ~/.bash_profile
           make pdf
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -10,15 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Anaconda
-        uses: goanpeca/setup-miniconda@v1
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: 3.7
-          environment-file: environment.yml
-          activate-environment: qe-lectures
       - name: TexLive Cache
         id: cache
         uses: actions/cache@v1
@@ -31,10 +22,19 @@ jobs:
           bash scripts/install_latex.sh
           echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> ~/.bash_profile
           source ~/.bash_profile
+      - name: Setup Anaconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: 3.7
+          environment-file: environment.yml
+          activate-environment: qe-lectures
       - name: Build PDF
         shell: bash -l {0}
         run: make pdf
       - uses: actions/upload-artifact@v2
         with:
           name: pdf
-          path: _build/jupyterpdf/quantitative_economics_with_python.pdf
+          path: _build/jupyterpdf/texbook/quantitative_economics_with_python.pdf

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -29,8 +29,8 @@ jobs:
         shell: bash -l {0}
         run: |
           bash scripts/install_latex.sh
-          # echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> $BASH_ENV
-          # source /home/circleci/.bashrc
+          echo 'export PATH=/tmp/texlive/bin/x86_64-linux:$PATH' >> ~/.bash_profile
+          source ~/.bash_profile
       - name: Build PDF
         shell: bash -l {0}
         run: make pdf

--- a/scripts/install_latex.sh
+++ b/scripts/install_latex.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# setup script to install texlive and add to path for travis
+# original source: https://shankarkulumani.com/2018/10/travis-and-latex.html
+sudo apt-get -qq update
+export PATH=/tmp/texlive/bin/x86_64-linux:$PATH
+if ! command -v pdflatex > /dev/null; then
+    echo "Texlive not installed"
+    echo "Downloading texlive and installing"
+    wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+    tar -xzf install-tl-unx.tar.gz
+    ./install-tl-*/install-tl --profile=./scripts/texlive.profile
+    echo "Finished install TexLive"
+fi
+echo "Now updating TexLive"
+# update texlive
+tlmgr option -- autobackup 0
+tlmgr update --self --all --no-auto-install
+echo "Finished updating TexLive"

--- a/scripts/texlive.profile
+++ b/scripts/texlive.profile
@@ -1,0 +1,10 @@
+selected_scheme scheme-full
+TEXDIR /tmp/texlive
+TEXMFCONFIG ~/.texlive/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /tmp/texlive/texmf-local
+TEXMFSYSCONFIG /tmp/texlive/texmf-config
+TEXMFSYSVAR /tmp/texlive/texmf-var
+TEXMFVAR ~/.texlive/texmf-var
+option_doc 0
+option_src 0


### PR DESCRIPTION
This PR adds framework files for installing texlive (via cache) to enable compilation of PDF files. 

- [x] figure out `.bashrc` in `github actions` context
- [x] check paths for artifact upload