### PR TITLE
UPD: rank_size usage in respective lectures

### DIFF
--- a/source/rst/heavy_tails.rst
+++ b/source/rst/heavy_tails.rst
@@ -417,7 +417,7 @@ Exercise 4
 
 Replicate the rank-size plot figure :ref:`presented above <rank_size_fig1>`.
 
-If you like you can use the function ``qe.rank_size_plot`` from the ``quantecon`` library to generate the plots.
+If you like you can use the function ``qe.rank_size`` from the ``quantecon`` library to generate the plots.
 
 Use ``np.random.seed(13)`` to set the seed.
 
@@ -597,7 +597,12 @@ Now we plot the data:
     
     for data, label, ax in zip(data_list, labels, axes):
 
-        qe.rank_size_plot(data, ax, label=label)
+        rank_data, size_data = qe.rank_size(data)
+
+        ax.loglog(rank_data, size_data, 'o', markersize=3.0, alpha=0.5, label=label)
+        ax.set_xlabel("log rank")
+        ax.set_ylabel("log size")
+
         ax.legend()
     
     fig.subplots_adjust(hspace=0.4)

--- a/source/rst/kesten_processes.rst
+++ b/source/rst/kesten_processes.rst
@@ -737,8 +737,11 @@ Now we produce the rank-size plot:
 
     fig, ax = plt.subplots()
     
-    qe.rank_size_plot(data, ax, c=0.01)
-    
+    rank_data, size_data = qe.rank_size(data, c=0.01)
+    ax.loglog(rank_data, size_data, 'o', markersize=3.0, alpha=0.5)
+    ax.set_xlabel("log rank")
+    ax.set_ylabel("log size")
+
     plt.show()
 
 The plot produces a straight line, consistent with a Pareto tail.

--- a/source/rst/wealth_dynamics.rst
+++ b/source/rst/wealth_dynamics.rst
@@ -576,7 +576,7 @@ At the same time, given the similarities, perhaps Pareto tails will arise.
 To test this, run a simulation that generates a cross-section of wealth and
 generate a rank-size plot.
 
-If you like, you can use the function ``rank_size_plot`` from the ``quantecon`` library (documentation `here <https://quanteconpy.readthedocs.io/en/latest/tools/inequality.html#quantecon.inequality.rank_size_plot>`__). 
+If you like, you can use the function ``rank_size`` from the ``quantecon`` library (documentation `here <https://quanteconpy.readthedocs.io/en/latest/tools/inequality.html#quantecon.inequality.rank_size>`__).
 
 In viewing the plot, remember that Pareto tails generate a straight line.  Is
 this what you see?
@@ -645,6 +645,9 @@ Now let's see the rank-size plot:
 
     fig, ax = plt.subplots()
 
-    qe.rank_size_plot(ψ_star, ax, c=0.001)
-    
+    rank_data, size_data = qe.rank_size(ψ_star, c=0.001)
+    ax.loglog(rank_data, size_data, 'o', markersize=3.0, alpha=0.5)
+    ax.set_xlabel("log rank")
+    ax.set_ylabel("log size")
+
     plt.show()


### PR DESCRIPTION
Following discussion in this quantecon-py [issue](https://github.com/QuantEcon/QuantEcon.py/issues/519), update all lectures using the `rank_size_plot` method of the `inequality.py` module to work with the refactored version `rank_size`, as per [this PR](https://github.com/QuantEcon/QuantEcon.py/pull/551).

The following lectures have been edited
- Heavy-Tailed Distributions
- Wealth Distribution Dynamics
- Kesten Processes and Firm Dynamics