### PR TITLE
[samuelson]_broken_link_fixed

### DIFF
--- a/source/rst/samuelson.rst
+++ b/source/rst/samuelson.rst
@@ -276,7 +276,7 @@ These can also be represented as
 .. math::  \lambda_2 = r (cos (\omega) - i \sin(\omega))
 
 (To read about the polar form, see
-`here <https://www.varsitytutors.com/hotmath/hotmath\_help/topics/polar-form-of-a-complex-number>`__)
+`here <https://www.khanacademy.org/math/precalculus/x9e81a4f98389efdf:complex/x9e81a4f98389efdf:complex-mul-div-polar/a/complex-number-polar-form-review>`__)
 
 Given **initial conditions** :math:`Y_{-1}, Y_{-2}`, we want to generate
 a **solution** of the difference equation :eq:`second_stochastic2`.


### PR DESCRIPTION
Hi @mmcky and @jstac , this PR fixes a broken link in``(To read about the polar form, see here)`` of lecture [samuelson](https://python.quantecon.org/samuelson.html#Mathematical-Analysis-of-the-Model) by replacing:
- the link https://www.varsitytutors.com/hotmath/hotmath\_help/topics/polar-form-of-a-complex-number (old) with https://www.khanacademy.org/math/precalculus/x9e81a4f98389efdf:complex/x9e81a4f98389efdf:complex-mul-div-polar/a/complex-number-polar-form-review (new)

Do you think it is a good idea?