### PR TITLE
[scalar_dynam]broken_link_fixed

### DIFF
--- a/source/rst/scalar_dynam.rst
+++ b/source/rst/scalar_dynam.rst
@@ -129,7 +129,7 @@ This made analysis of dynamics very easy.
 
 When models are nonlinear, however, the situation can be quite different.
 
-For example, recall how we `previously studied <http://python-programming.quantecon.org/python_oop.html#Example:-The-Solow-Growth-Model>`__ the law of motion for the Solow growth model, a simplified version of which is
+For example, recall how we `previously studied <https://python-programming.quantecon.org/python_oop.html#example-the-solow-growth-model>`__ the law of motion for the Solow growth model, a simplified version of which is
 
 .. math::
     :label: solow_lom2


### PR DESCRIPTION
Hi @mmcky and @jstac , this PR fixes a broken link in lecture [scalar_dynam](https://python.quantecon.org/scalar_dynam.html#Example:-A-Nonlinear-Model) by replacing:
- the old link http://python-programming.quantecon.org/python_oop.html#Example:-The-Solow-Growth-Model with the new link https://python-programming.quantecon.org/python_oop.html#example-the-solow-growth-model