### PR TITLE
[1_geom_series]_small_modify

### DIFF
--- a/source/rst/geom_series.rst
+++ b/source/rst/geom_series.rst
@@ -102,7 +102,7 @@ The key formula here is
 
 .. math:: 1 + c + c^2 + c^3 + \cdots + c^T  = \frac{1 - c^{T+1}}{1-c}
 
-**Remark:** The above formula works for any value of the scalar
+**Remark:** The above formulas work for any value of the scalar
 :math:`c`. We don't have to restrict :math:`c` to be in the
 set :math:`(-1,1)`.
 


### PR DESCRIPTION
Good morning @jstac , this PR makes the following modification in the **remark** of section ``Key Formula`` within lecture [geom_series](https://python.quantecon.org/geom_series.html#Key-Formulas):
- ``The above formula works for`` -->> ``The above formulas work for``

I suggest this change because you mentioned two key formulae for two cases: infinite and finite geometric series; also be consistent with the section title.