### PR TITLE
[4_linear_algebra]_add_:math:

### DIFF
--- a/source/rst/linear_algebra.rst
+++ b/source/rst/linear_algebra.rst
@@ -1457,7 +1457,7 @@ equation gives
 
     (Q + B'PB)u + B'PAx = 0
 
-which is the first-order condition for maximizing L w.r.t. u.
+which is the first-order condition for maximizing :math:`L` w.r.t. :math:`u`.
 
 Thus, the optimal choice of u must satisfy
 


### PR DESCRIPTION
Hi @jstac , this PR adds ":math:" to ``L`` and ``u`` in the following sentence of lecture [linear_algebra](https://python.quantecon.org/linear_algebra.html#Solutions):
- ``which is the first-order condition for maximizing L w.r.t. u.``