### PR TITLE
[9_time_series_with_matrices]_typos

### DIFF
--- a/source/rst/time_series_with_matrices.rst
+++ b/source/rst/time_series_with_matrices.rst
@@ -67,7 +67,7 @@ But actually, it is a collection of :math:`T` simultaneous linear
 equations in the :math:`T` variables :math:`y_1, y_2, \ldots, y_T`.
 
 **Note:** To be able to solve a second-order linear difference
-equations, we require two **boundary conditions** that can take the form
+equation, we require two **boundary conditions** that can take the form
 either of two **initial conditions** or two **terminal conditions** or
 possibly one of each.
 
@@ -211,7 +211,7 @@ Adding a random term
 =====================
 
 To generate some excitement, we'll follow in the spirit of the great economists
-Eugen Slusky and Ragnar Frisch and replace our original second-order difference
+Eugen Slutsky and Ragnar Frisch and replace our original second-order difference
 equation with the following **second-order stochastic linear difference
 equation**:
 


### PR DESCRIPTION
Dear @jstac , this PR corrects following typos in lecture [time_series_with_matrices](https://python.quantecon.org/time_series_with_matrices.html):
- ``solve a second-order linear difference equations`` -->> ``solve a second-order linear difference equation``
- ``Eugen Slusky`` -->> ``Eugen Slutsky``