### PR TITLE
[12_finite_markov]_typos

### DIFF
--- a/source/rst/finite_markov.rst
+++ b/source/rst/finite_markov.rst
@@ -683,7 +683,7 @@ Aperiodicity
 ----------------
 
 
-Loosely speaking, a Markov chain is called periodic if it cycles in a predictible way, and aperiodic otherwise.
+Loosely speaking, a Markov chain is called periodic if it cycles in a predictable way, and aperiodic otherwise.
 
 Here's a trivial example with three states
 
@@ -885,7 +885,7 @@ with the unit eigenvalue :math:`\lambda = 1`.
 
 A more stable and sophisticated algorithm is implemented in `QuantEcon.py <http://quantecon.org/quantecon-py>`__.
 
-This is the one we recommend you use:
+This is the one we recommend you to use:
 
 .. code-block:: python3
 


### PR DESCRIPTION
Hi @jstac , this PR corrects following typos in lecture [finite_markov](https://python.quantecon.org/finite_markov.html):
- ``if it cycles in a predictible way`` -->> ``if it cycles in a predictable way``
- ``This is the one we recommend you use`` -->> ``This is the one we recommend you to use``