### PR TITLE
[14_linear_models]_shift_footnote's_cite

### DIFF
--- a/source/rst/linear_models.rst
+++ b/source/rst/linear_models.rst
@@ -399,7 +399,7 @@ With the deterministic seasonal, the transition matrix becomes
         \end{bmatrix}
 
 
-It is easy to check that :math:`A^4 = I`, which implies that :math:`x_t` is strictly periodic with period 4:[#foot1]_
+It is easy to check that :math:`A^4 = I`, which implies that :math:`x_t` is strictly periodic with period 4[#foot1]_:
 
 .. math::
 


### PR DESCRIPTION
Good afternoon. @jstac , this PR puts a footnote's citation inside the comma in lecture [linear_models](https://python.quantecon.org/linear_models.html):
- ``which implies that :math:`x_t` is strictly periodic with period 4:[#foot1]_`` -->> ``which implies that :math:`x_t` is strictly periodic with period 4[#foot1]_:``