### PR TITLE
[15_samuelson]_modify_lists

### DIFF
--- a/source/rst/samuelson.rst
+++ b/source/rst/samuelson.rst
@@ -71,9 +71,9 @@ represent a model of national output based on three components:
    times the difference in output between period :math:`t-1` and
    :math:`t-2`.
 
--  the idea that consumption plus investment plus government purchases
-   constitute *aggregate demand,* which automatically calls forth an
-   equal amount of *aggregate supply*.
+Consumption plus investment plus government purchases
+constitute *aggregate demand,* which automatically calls forth an
+equal amount of *aggregate supply*.
 
 (To read about linear difference equations see `here <https://en.wikipedia.org/wiki/Linear\_difference\_equation>`__ or chapter IX of :cite:`Sargent1987`)
 


### PR DESCRIPTION
Good morning @jstac , this PR puts the following outside the lists following ``Samuelson used a *second-order linear difference equation* to represent a model of national output based on three components:`` in [section Samuelson's Model of lecture samuelson](https://python.quantecon.org/samuelson.html#Samuelson%E2%80%99s-Model):
- ``The idea that consumption plus investment plus government purchases constitute *aggregate demand,* which automatically calls forth an equal amount of *aggregate supply*.``

I made this change because the other 3 points in the list are 3 components of the national output model mentioned above, but this point/sentence does not. It sounds like a remark on these 3 model components, so I treat it as a separate sentence outside the list.