### PR TITLE
[16_kesten_processes]_typo

### DIFF
--- a/source/rst/kesten_processes.rst
+++ b/source/rst/kesten_processes.rst
@@ -528,7 +528,7 @@ In this setting, firm dynamics can be expressed as
 
 Here
 
-* the state variable :math:`s_t` is represents productivity (which is a proxy
+* the state variable :math:`s_t` represents productivity (which is a proxy
   for output and hence firm size),
 * the IID sequence :math:`\{ e_t \}` is thought of as a productivity draw for a new
   entrant and


### PR DESCRIPTION
Hi @jstac , this PR corrects a typo in lecture [kesten_processes](https://python.quantecon.org/kesten_processes.html):
- "the state variable :math:`s_t` is represents productivity" --> "the state variable :math:`s_t` represents productivity"