### PR TITLE
[17_wealth_dynamics]_typo

### DIFF
--- a/source/rst/wealth_dynamics.rst
+++ b/source/rst/wealth_dynamics.rst
@@ -554,7 +554,7 @@ For the values of the tail index, use ``a_vals = np.linspace(1, 10, 25)``.
 
 Use sample of size 1,000 for each :math:`a` and the sampling method for generating Pareto draws employed in the discussion of Lorenz curves for the Pareto distribution.
 
-To the extend that you can, interpret the monotone relationship between the
+To the extent that you can, interpret the monotone relationship between the
 Gini index and :math:`a`.
 
 


### PR DESCRIPTION
Hi @jstac , this PR corrects a typo in lecture [wealth_dynamics](https://python.quantecon.org/wealth_dynamics.html):
- ``To the extend that you can`` -->> ``To the extent that you can``