### PR TITLE
[21_cass_koopmans_2]_typos

### DIFF
--- a/source/rst/cass_koopmans_2.rst
+++ b/source/rst/cass_koopmans_2.rst
@@ -425,7 +425,7 @@ Guess for Price System
 In this lecture :doc:`Cass-Koopmans Planning Model <cass_koopmans_1>`, we  computed an allocation :math:`\{\vec{C}, \vec{K}, \vec{N}\}`
 that solves the planning problem.
 
-(This allocation will constitute the **Big** :math:`K`  to be in the presence instance of the *Big** :math:`K` **, little** :math:`k` trick
+(This allocation will constitute the **Big** :math:`K`  to be in the present instance of the *Big** :math:`K` **, little** :math:`k` trick
 that we'll apply to  a competitive equilibrium in the spirit of `this lecture <https://lectures.quantecon.org/py/rational_expectations.html#>`__
 and  `this lecture <https://lectures.quantecon.org/py/dyn_stack.html#>`__.)
 
@@ -621,7 +621,7 @@ representative household living in a competitive equilibrium.
 We now turn to  the problem faced by a firm in a competitive
 equilibrium:
 
-If we plug in :eq:`eq-pl` into :eq:`Zero-profits` for all t, we
+If we plug :eq:`eq-pl` into :eq:`Zero-profits` for all t, we
 get
 
 .. math::


### PR DESCRIPTION
Good afternoon, @jstac , this PR corrects the following two typos in lecture [cass_koopmans_2](https://python.quantecon.org/cass_koopmans_2.html):
- ``This allocation will constitute the **Big** :math:`K`  to be in the presence instance of the *Big** :math:`K` **, little** :math:`k` trick`` -->> ``This allocation will constitute the **Big** :math:`K`  to be in the present instance of the *Big** :math:`K` **, little** :math:`k` trick``
- ``If we plug in :eq:`eq-pl` into :eq:`Zero-profits` for all t`` -->> ``If we plug :eq:`eq-pl` into :eq:`Zero-profits` for all t``