### PR TITLE
[22_mccall_model]_add_.

### DIFF
--- a/source/rst/mccall_model.rst
+++ b/source/rst/mccall_model.rst
@@ -334,7 +334,7 @@ itself via
 
 
 (A new vector :math:`Tv` is obtained from given vector :math:`v` by evaluating
-the r.h.s. at each :math:`i`)
+the r.h.s. at each :math:`i`.)
 
 The element :math:`v_k` in the sequence :math:`\{v_k\}` of successive
 approximations corresponds to :math:`T^k v`.


### PR DESCRIPTION
Hi @jstac , this PR adds ``.`` at the end of the following sentence within brackets in lecture [mccall_model](https://python.quantecon.org/mccall_model.html):
- "A new vector :math:`Tv` is obtained from given vector :math:`v` by evaluating the r.h.s. at each :math:`i`"