### PR TITLE
[23_mccall_model_with_separation]_add_.

### DIFF
--- a/source/rst/mccall_model_with_separation.rst
+++ b/source/rst/mccall_model_with_separation.rst
@@ -121,7 +121,7 @@ If he rejects, then he receives unemployment compensation :math:`c`.
 
 The process then repeats.
 
-(Note: we do not allow for job search while employed---this topic is taken up in a :doc:`later lecture <jv>`)
+(Note: we do not allow for job search while employed---this topic is taken up in a :doc:`later lecture <jv>`.)
 
 
 


### PR DESCRIPTION
Hi @jstac , this PR adds ``.`` at the end of the following sentence within brackets in lecture [mccall_model_with_separation](https://python.quantecon.org/mccall_model_with_separation.html):
- "Note: we do not allow for job search while employed---this topic is taken up in a :doc:`later lecture <jv>`"