### PR TITLE
[24_mccall_fitted_vfi]_typo

### DIFF
--- a/source/rst/mccall_fitted_vfi.rst
+++ b/source/rst/mccall_fitted_vfi.rst
@@ -361,7 +361,7 @@ support.
 
 Use ``s_vals = np.linspace(1.0, 2.0, 15)`` and ``m = 2.0``.
 
-State how you expect the reservation wage vary with :math:`s`.
+State how you expect the reservation wage to vary with :math:`s`.
 
 Now compute it.  Is this as you expected?
 


### PR DESCRIPTION
Hi @jstac , this PR corrects the following possible typo in lecture [mccall_fitted_vfi](https://python.quantecon.org/mccall_fitted_vfi.html):
- "State how you expect the reservation wage vary with :math:`s`." -->> "State how you expect the reservation wage to vary with :math:`s`."