### PR TITLE
[24_mccall_fitted_vfi]_add_.

### DIFF
--- a/source/rst/mccall_fitted_vfi.rst
+++ b/source/rst/mccall_fitted_vfi.rst
@@ -341,7 +341,7 @@ Exercise 1
 Use the code above to explore what happens to the reservation wage when the wage parameter :math:`\mu`
 changes.
 
-Use the default parameters and :math:`\mu` in ``mu_vals = np.linspace(0.0, 2.0, 15)``
+Use the default parameters and :math:`\mu` in ``mu_vals = np.linspace(0.0, 2.0, 15)``.
 
 Is the impact on the reservation wage as you expected?
 


### PR DESCRIPTION
Good morning, @jstac , this PR adds ``.`` at the end of the following sentence in lecture [mccall_fitted_vfi](https://python.quantecon.org/mccall_fitted_vfi.html):
- "Use the default parameters and :math:`\mu` in ``mu_vals = np.linspace(0.0, 2.0, 15)``"