### PR TITLE
[27_jv]_typo

### DIFF
--- a/source/rst/jv.rst
+++ b/source/rst/jv.rst
@@ -224,7 +224,7 @@ We will set up a class ``JVWorker`` that holds the parameters of the model descr
 
 
 The function ``operator_factory`` takes an instance of this class and returns a
-jitted version of the Bellman operator ``T``, ie.
+jitted version of the Bellman operator ``T``, i.e.
 
 .. math::
 


### PR DESCRIPTION
Hi @jstac , this PR corrects a possible typo in lecture [jv](https://python.quantecon.org/jv.html):
- ``ie.``-->> ``i.e.``

For reference, please see [here](https://english.stackexchange.com/questions/407270/is-ie-acceptable-or-must-it-always-be-i-e).