### PR TITLE
[29_cake_eating_numerical]_delete_.

### DIFF
--- a/source/rst/cake_eating_numerical.rst
+++ b/source/rst/cake_eating_numerical.rst
@@ -98,7 +98,7 @@ The Bellman Operator
 --------------------
 
 We introduce the **Bellman operator** :math:`T` that takes a function `v` as an
-argument and returns a new function :math:`Tv` defined by.
+argument and returns a new function :math:`Tv` defined by
 
 .. math::
 


### PR DESCRIPTION
Hi @jstac , this PR deletes an inappropriate ``.`` in lecture [cake_eating_numerical](https://python.quantecon.org/cake_eating_numerical.html#The-Bellman-Operator):
- "We introduce the **Bellman operator** :math:`T` that takes a function `v` as an argument and returns a new function :math:`Tv` defined by. 
.. math::

    Tv(x) = \max_{0 \leq c \leq x} \{u(c) + \beta v(x - c)\}" 
-->>
"We introduce the **Bellman operator** :math:`T` that takes a function `v` as an argument and returns a new function :math:`Tv` defined by 
.. math::

    Tv(x) = \max_{0 \leq c \leq x} \{u(c) + \beta v(x - c)\}"