### PR TITLE
[30_optgrowth]_add_.

### DIFF
--- a/source/rst/optgrowth.rst
+++ b/source/rst/optgrowth.rst
@@ -859,7 +859,7 @@ utility specification.
 Setting :math:`\gamma = 1.5`, compute and plot an estimate of the optimal policy.
 
 
-Time how long this function takes to run, so you can compare it to faster code developed in the :doc:`next lecture <optgrowth_fast>`
+Time how long this function takes to run, so you can compare it to faster code developed in the :doc:`next lecture <optgrowth_fast>`.
 
 
 .. _og_ex2:


### PR DESCRIPTION
Hi @jstac , this PR adds ``.`` at the end of the following sentence in lecture [optgrowth](https://python.quantecon.org/optgrowth.html#Exercises):
- "Time how long this function takes to run, so you can compare it to faster code developed in the :doc:`next lecture <optgrowth_fast>`"