### PR TITLE
[35_ifp_advanced]_typos

### DIFF
--- a/source/rst/ifp_advanced.rst
+++ b/source/rst/ifp_advanced.rst
@@ -335,7 +335,7 @@ radius of the matrix :math:`L` defined by
 
     L(z, \hat z) := P(z, \hat z) \int R(\hat z, x) \phi(x) dx
 
-This indentity is proved in :cite:`ma2020income`, where :math:`\phi` is the
+This identity is proved in :cite:`ma2020income`, where :math:`\phi` is the
 density of the innovation :math:`\zeta_t` to returns on assets.  
 
 (Remember that :math:`\mathsf Z` is a finite set, so this expression defines a matrix.)
@@ -642,7 +642,7 @@ For example, we will pass in the solutions ``a_star, σ_star`` along with
 ``ifp``, even though it would be more natural to just pass in ``ifp`` and then
 solve inside the function.
 
-The reason we do this is because ``solve_model_time_iter`` is not
+The reason we do this is that ``solve_model_time_iter`` is not
 JIT-compiled.
 
 


### PR DESCRIPTION
Hi @jstac , this PR corrects typos in lecture [ifp_advanced](https://python.quantecon.org/ifp_advanced.html):
- ``indentity`` -->> ``identity``
- "The reason we do this is because ``solve_model_time_iter`` is not JIT-compiled." -->> ""The reason we do this is that ``solve_model_time_iter`` is not JIT-compiled.""