### PR TITLE
[35_ifp_advanced]_add_.

### DIFF
--- a/source/rst/ifp_advanced.rst
+++ b/source/rst/ifp_advanced.rst
@@ -249,7 +249,7 @@ It can be shown that
 
 We now have a clear path to successfully approximating the optimal policy:
 choose some :math:`\sigma \in \mathscr C` and then iterate with :math:`K` until
-convergence (as measured by the distance :math:`\rho`)
+convergence (as measured by the distance :math:`\rho`).
 
 
 


### PR DESCRIPTION
Good morning @jstac , this PR adds ``.`` at the end of the following sentence in lecture [ifp_advanced](https://python.quantecon.org/ifp_advanced.html):
- "We now have a clear path to successfully approximating the optimal policy: choose some :math:`\sigma \in \mathscr C` and then iterate with :math:`K` until convergence (as measured by the distance :math:`\rho`)"