### PR TITLE
[38_wald_friedman]_repharse

### DIFF
--- a/source/rst/wald_friedman.rst
+++ b/source/rst/wald_friedman.rst
@@ -799,7 +799,7 @@ Before you look, think about what will happen:
     wf = WaldFriedman(c=2.5)
     simulation_plot(wf)
 
-Increased cost per draw has induced the decision-maker to take less draws before deciding.
+Increased cost per draw has induced the decision-maker to take fewer draws before deciding.
 
 Because he decides with less, the percentage of time he is correct drops.
 


### PR DESCRIPTION
Hi @jstac , this PR rephrases a word in lecture [wald_friedman](https://python.quantecon.org/wald_friedman.html):
- ``Increased cost per draw has induced the decision-maker to take less draws before deciding.`` -->> ``Increased cost per draw has induced the decision-maker to take fewer draws before deciding.``

It might be better to use ``fewer``, instead of ``less`` here, because the following word ``draws`` is plural.