### PR TITLE
[CI] Update Anaconda=2020.11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - default
 dependencies:
   - python=3.8
-  - anaconda=2020.07
+  - anaconda=2020.11
   - pip
   - pip:
     - quantecon


### PR DESCRIPTION
This PR updates the `anaconda==2020.11` pin. 

There are currently some issues with the `publishing` side of things when using the template files:

- [ ] not reading `article.tpxl` for `jinja` extend of `latex.tpl`
- [ ] not able to read `html.tpl` using `jinja2` #328 

**Note:** all tests run so the actual lectures run fine in the latest `anaconda` -- this just impacts publishing and building.