### PR TITLE
[41_navy_captain]_typos_spaces

### DIFF
--- a/source/rst/navy_captain.rst
+++ b/source/rst/navy_captain.rst
@@ -56,8 +56,8 @@ this lecture :doc:`Exchangeability and Bayesian Updating <exchangeable>` and in 
 :doc:`Likelihood Ratio Processes <likelihood_ratio_process>`, which describes the link between Bayesian
 updating and likelihood ratio processes.  
 
-The present lecture  uses Python to generate simulations that   evaluate expected losses under  **frequentist** and **Bayesian**
-decision rules for a instances of the Navy Captain's decision problem.  
+The present lecture uses Python to generate simulations that evaluate expected losses under **frequentist** and **Bayesian**
+decision rules for an instance of the Navy Captain's decision problem.  
 
 The simulations validate the Navy Captain's hunch that there is a better rule than the one the Navy had ordered him
 to use.  
@@ -121,7 +121,7 @@ Below is some Python code that sets up these objects.
         return r * x**(a-1) * (1 - x)**(b-1)
 
 We start with defining a ``jitclass`` that stores parameters and
-functions we need to solve problems for both the bayesian and
+functions we need to solve problems for both the Bayesian and
 frequentist Navy Captains.
 
 .. code-block:: python3


### PR DESCRIPTION
Hi @jstac , this PR does two tasks in lecture [navy_captain](https://python.quantecon.org/navy_captain.html):
- deletes some extra `` `` (spaces)
- corrects following typos:
   - ``The present lecture uses Python to generate simulations that evaluate expected losses under **frequentist** and **Bayesian** decision rules for a instance of the Navy Captain's decision problem. `` -->> ``The present lecture uses Python to generate simulations that evaluate expected losses under **frequentist** and **Bayesian** decision rules for an instance of the Navy Captain's decision problem. ``
   - ``bayesian`` -->> ``Bayesian``
   - ``soley`` -->> ``solely``
   - ``For our parameter settings, we can compute it’s value:`` -->> ``For our parameter settings, we can compute its value:``
   - ``frequentist rule’sfixed :math:`t`.`` -->> ``frequentist rule’s fixed :math:`t`.``