### PR TITLE
[8_multivariate_normal]_typo2

### DIFF
--- a/source/rst/multivariate_normal.rst
+++ b/source/rst/multivariate_normal.rst
@@ -27,7 +27,7 @@ In this lecture, you will learn formulas for
 
 * marginal distributions for all subvectors of :math:`x`
 
-* conditional distributions for subvectors of 'math:`x` conditional on other subvectors of :math:`x`
+* conditional distributions for subvectors of :math:`x` conditional on other subvectors of :math:`x`
 
 We will use  the multivariate normal distribution to formulate some classic models:
 


### PR DESCRIPTION
Hi @jstac , this PR corrects a typo in lecture: [Multivariate Normal Distribution](https://python.quantecon.org/multivariate_normal.html#Overview).

This fixes the sentence: 
![Screen Shot 2021-01-08 at 5 50 50 pm](https://user-images.githubusercontent.com/44494439/103983816-0e536980-51da-11eb-85bd-d2d045c72491.png)
