### PR TITLE
[wald_friedman] update jitclass imports

### DIFF
--- a/source/rst/wald_friedman.rst
+++ b/source/rst/wald_friedman.rst
@@ -64,7 +64,8 @@ We'll begin with some imports:
 
     import numpy as np
     import matplotlib.pyplot as plt
-    from numba import jit, prange, jitclass, float64, int64
+    from numba import jit, prange, float64, int64
+    from numba.experimental import jitclass
     from interpolation import interp
     from math import gamma
 


### PR DESCRIPTION
Hi @jstac and @mmcky , this PR makes the following changes in lecture [wald_friedman](https://python.quantecon.org/wald_friedman.html) to fix the issue mentioned in the ``lecture-python.md``(https://github.com/QuantEcon/lecture-python.myst/issues/27):
- ``from numba import jit, prange, jitclass, float64, int64`` -->> line1: ``from numba import jit, prange, float64, int64`` and line2: ``from numba.experimental import jitclass``