### PR TITLE
[48_rationa_expectations] typo

### DIFF
--- a/source/rst/rational_expectations.rst
+++ b/source/rst/rational_expectations.rst
@@ -91,7 +91,7 @@ A Simple Static Example of the Big Y, Little y Trick
 
 Consider a static model in which a collection of :math:`n` firms produce a homogeneous good that is sold in a competitive market.
 
-Each of these :math:`n` firms sell output :math:`y`.
+Each of these :math:`n` firms sells output :math:`y`.
 
 The price :math:`p` of the good lies on an inverse demand curve
 


### PR DESCRIPTION
Hi @jstac , this PR corrects the following typo in lecture [rationa_expectations](https://python.quantecon.org/rational_expectations.html):
- ``Each of these :math:`n` firms sell output :math:`y`.`` -->> ``Each of these :math:`n` firms sells output :math:`y`.``