### PR TITLE
[53_markov_asset] modify list numbers

### DIFF
--- a/source/rst/markov_asset.rst
+++ b/source/rst/markov_asset.rst
@@ -306,10 +306,10 @@ where
 #. :math:`\{X_t\}` is a finite Markov chain with state space :math:`S` and
    transition probabilities
 
-.. math::
+    .. math::
 
-    P(x, y) := \mathbb P \{ X_{t+1} = y \,|\, X_t = x \}
-    \qquad (x, y \in S)
+        P(x, y) := \mathbb P \{ X_{t+1} = y \,|\, X_t = x \}
+        \qquad (x, y \in S)
 
 
 #. :math:`g` is a given function on :math:`S` taking positive values


### PR DESCRIPTION
Hi @jstac and @mmcky , there is an issue on one list in lecture ``markov_asset``. 

Please see [here](https://python.quantecon.org/markov_asset.html#Example-3:-Markov-Growth,-Risk-Neutral-Pricing) or the following screenshot:
![Screen Shot 2021-01-12 at 1 39 06 pm](https://user-images.githubusercontent.com/53931041/104262372-976ce800-54db-11eb-949a-8e52c3933463.png)

This issue is caused by the indention of the Latex equation above the line with red circles.

This PR fixes this issue.