### PR TITLE
[15_samuelson]remove

### DIFF
--- a/source/rst/samuelson.rst
+++ b/source/rst/samuelson.rst
@@ -785,14 +785,6 @@ We can also use sympy to compute analytic formulas for the roots
 
     sympy.solve(z**2 - r1*z - r2, z)
 
-
-.. math::
-
-    \left [ \frac{\rho_{1}}{2} - \frac{1}{2} \sqrt{\rho_{1}^{2} + 4 \rho_{2}},
-    \quad \frac{\rho_{1}}{2} + \frac{1}{2} \sqrt{\rho_{1}^{2} + 4 \rho_{2}}\right ]
-
-
-
 .. code-block:: python3
 
     a = Symbol("α")
@@ -801,13 +793,6 @@ We can also use sympy to compute analytic formulas for the roots
     r2 = -b
 
     sympy.solve(z**2 - r1*z - r2, z)
-
-.. math::
-
-    \left [ \frac{\alpha}{2} + \frac{\beta}{2} - \frac{1}{2} \sqrt{\alpha^{2} +
-    2 \alpha \beta + \beta^{2} - 4 \beta}, \quad \frac{\alpha}{2} +
-    \frac{\beta}{2} + \frac{1}{2} \sqrt{\alpha^{2} + 2 \alpha \beta +
-    \beta^{2} - 4 \beta}\right ]
 
 
 
@@ -1293,14 +1278,6 @@ Samuelson model using a method in the ``LinearStateSpace`` class
     y1 = imres[:, :, 0]
     y2 = imres[:, :, 1]
     y1.shape
-
-
-
-
-.. math::
-
-    \left ( 2, \quad 6, \quad 1\right )
-
 
 
 Now let's compute the zeros of the characteristic polynomial by simply


### PR DESCRIPTION
Hi @jstac ,

I guess that these below math expressions in markdown may be redundant because the codes' outputs show the answers. So this PR removes them all.

![Screen Shot 2021-01-18 at 4 37 21 pm](https://user-images.githubusercontent.com/44494439/104876358-9fc99500-59ab-11eb-8cad-6fe105f14020.png)
![Screen Shot 2021-01-18 at 4 38 10 pm](https://user-images.githubusercontent.com/44494439/104876362-a3f5b280-59ab-11eb-8d4b-a4a118042e9a.png)


