### PR TITLE
[36_odu]broken_reference

### DIFF
--- a/source/rst/odu.rst
+++ b/source/rst/odu.rst
@@ -444,7 +444,7 @@ We will also plot the optimal policy
     plt.show()
 
 The results fit well with our intuition from section `looking
-forward <#looking-forward>`__.
+forward <#Looking-Forward>`__.
 
 -  The black line in the figure above corresponds to the function
    :math:`\bar w(\pi)` introduced there.


### PR DESCRIPTION
Hi @jstac ,

This PR fixes the wrong internal reference.
In the sentence below, 
![Screen Shot 2021-01-19 at 2 20 42 pm](https://user-images.githubusercontent.com/44494439/104983805-9c90e080-5a61-11eb-912b-9566f7a943da.png)

the internal reference link "looking forward" should refer to [this section](https://python.quantecon.org/odu.html#Looking-Forward) as it says, but it wrongly refers to [the begin section](https://python.quantecon.org/odu.html#looking-forward). 

This happens because it uses wrong link as follows:
wrong link: https://python.quantecon.org/odu.html#looking-forward
correct link: https://python.quantecon.org/odu.html#Looking-Forward