### PR TITLE
[36_odu]broken_reference2

### DIFF
--- a/source/rst/odu.rst
+++ b/source/rst/odu.rst
@@ -670,7 +670,7 @@ Use the default parameters and ``Q_factory`` to compute an optimal
 policy.
 
 Your result should coincide closely with the figure for the optimal
-policy `shown above <#odu-pol-vfi>`__.
+policy `shown above <#Take-1:-Solution-by-VFI>`__.
 
 Try experimenting with different parameters, and confirm that the change
 in the optimal policy coincides with your intuition.


### PR DESCRIPTION
Hi @jstac ,

I guess that this sentence also uses wrong internal reference link.
![Screen Shot 2021-01-19 at 2 41 02 pm](https://user-images.githubusercontent.com/44494439/104985155-70c32a00-5a64-11eb-8b9a-8d34a4a57f69.png)

The "shown above" uses https://python.quantecon.org/odu.html#odu-pol-vfi. However, there is no section link named #odu-pol-vfi, and it just leads to the first title page.

From the context, I guess that the "shown above" may link to [this section](https://python.quantecon.org/odu.html#Take-1:-Solution-by-VFI). So I changed the broken link to this one.