### PR TITLE
[36_odu]typo

### DIFF
--- a/source/rst/odu.rst
+++ b/source/rst/odu.rst
@@ -1080,10 +1080,10 @@ not, when the actual ruling distribution is :math:`g` instead of
 Two countervailing effects are at work.
 
 
--  if f generates successive wage offers, then :math:`w` is more likely to be low, but
+-  if :math:`f` generates successive wage offers, then :math:`w` is more likely to be low, but
    :math:`\pi` is moving up toward to 1, which lowers the reservation wage,
    i.e., the worker becomes  less selective the longer he or she remains unemployed.
--  if g generates wage offers, then :math:`w` is more likely to be high, but
+-  if :math:`g` generates wage offers, then :math:`w` is more likely to be high, but
    :math:`\pi` is moving downward toward 0, increasing the reservation wage, i.e., the worker becomes  more selective
    the longer he or she remains unemployed.
 


### PR DESCRIPTION
Hi @jstac ,

I think that the distribution 'f' and 'g' in these sentences should take math expression. So this PR adds ```:math:``` for 'f' and 'g'.
```Left```: the current website ```Right```: netlify,app display after this PR
![Screen Shot 2021-01-19 at 3 04 07 pm](https://user-images.githubusercontent.com/44494439/104986838-28a60680-5a68-11eb-968d-3c9b63c5d18d.png)
