### PR TITLE
[41_navy_captain]typo

### DIFF
--- a/source/rst/navy_captain.rst
+++ b/source/rst/navy_captain.rst
@@ -612,7 +612,7 @@ The Bayesian decision rule is:
 -  delay deciding and draw another :math:`z` if
    :math:`\beta \leq \pi \leq \alpha`
 
-We can calculate two ‘’objective’’ loss functions under this situation
+We can calculate two “objective” loss functions under this situation
 conditioning on knowing for sure that nature has selected :math:`f_{0}`,
 in the first case, or :math:`f_{1}`, in the second case.
 


### PR DESCRIPTION
Hi @jstac ,
This PR fixes a minor typo.
```Left```: the current website ```Right```: netlify.app display after this PR
![Screen Shot 2021-01-19 at 6 43 45 pm](https://user-images.githubusercontent.com/44494439/105003299-995c1b80-5a86-11eb-8ab8-ec00bb4c0d68.png)
