### PR TITLE
[42_lqcontrol]typo

### DIFF
--- a/source/rst/lqcontrol.rst
+++ b/source/rst/lqcontrol.rst
@@ -603,7 +603,7 @@ are wrapped in a class  called ``LQ``, which includes
 
 * Instance data:
 
-  * The required parameters :math:`Q, R, A, B` and optional parameters :math:`C, β, T, R_f, N` specifying a given LQ model
+  * The required parameters :math:`Q, R, A, B` and optional parameters :math:`C, \beta, T, R_f, N` specifying a given LQ model
 
     * set :math:`T` and :math:`R_f` to ``None`` in the infinite horizon case
 

--- a/source/rst/lqcontrol.rst
+++ b/source/rst/lqcontrol.rst
@@ -603,7 +603,7 @@ are wrapped in a class  called ``LQ``, which includes
 
 * Instance data:
 
-  * The required parameters :math:`Q, R, A, B` and optional parameters `C, β, T, R_f, N` specifying a given LQ model
+  * The required parameters :math:`Q, R, A, B` and optional parameters :math:`C, β, T, R_f, N` specifying a given LQ model
 
     * set :math:`T` and :math:`R_f` to ``None`` in the infinite horizon case
 


### PR DESCRIPTION
Hi @jstac ,

This PR fixes a typo by adding ```:math:``` .

Since my first commit "[42_lqcontrol]typo" results in displaying somewhat awkward for ```β``` in netlify.app, I changed  ```β``` to ```\beta``` in "[42_lqcontrol]typo_beta".

Here is the result of the two commits.
```Left```: current website ```Right```: the result display of this PR
![Screen Shot 2021-01-20 at 9 37 26 am](https://user-images.githubusercontent.com/44494439/105102751-6441de80-5b03-11eb-9e4c-927563baa1f6.png)
