### PR TITLE
[45_lq_inventories]typo

### DIFF
--- a/source/rst/lq_inventories.rst
+++ b/source/rst/lq_inventories.rst
@@ -315,7 +315,7 @@ its consequences.
 Notice that the above code sets parameters at the following default
 values
 
--  discount factor β=0.96,
+-  discount factor :math:`β=0.96`,
 
 -  inverse demand function: :math:`a0=10, a1=1`
 

--- a/source/rst/lq_inventories.rst
+++ b/source/rst/lq_inventories.rst
@@ -315,7 +315,7 @@ its consequences.
 Notice that the above code sets parameters at the following default
 values
 
--  discount factor :math:`β=0.96`,
+-  discount factor :math:`\beta=0.96`,
 
 -  inverse demand function: :math:`a0=10, a1=1`
 


### PR DESCRIPTION
Hi @jstac ,
This PR fixes a typo by adding ```:math:```.

As the netlify.app display after my first commit shows little awkward ```β```, I changed ```β``` to ```\beta``` in second commit [45_lq_inventories]typo_beta.

Here is the result of this PR after two commits:
```Left```: the current website ```Right```: the result display of this PR
![Screen Shot 2021-01-20 at 9 32 55 am](https://user-images.githubusercontent.com/44494439/105101205-9c94ed00-5b02-11eb-8f73-d1f01c25ebb7.png)
