### PR TITLE
[19_short_path] fix issue 61 mentioned in repo lecutre-python.myst

### DIFF
--- a/source/rst/short_path.rst
+++ b/source/rst/short_path.rst
@@ -60,7 +60,7 @@ We wish to travel from node (vertex) A to node G at minimum cost
 * Arrows (edges) indicate the movements we can take.
 * Numbers on edges indicate the cost of traveling that edge.
 
-(Graphs such as the one above are called **weighted `directed graphs <https://en.wikipedia.org/wiki/Directed_graph>`_**.)
+(Graphs such as the one above are called weighted `directed graphs <https://en.wikipedia.org/wiki/Directed_graph>`_.)
 
 Possible interpretations of the graph include
 


### PR DESCRIPTION
Hi @jstac and @mmcky , as discussed with @mmcky in lecture-python.myst's [issue #61](https://github.com/QuantEcon/lecture-python.myst/issues/61), this PR fixes that issue by
- ``**weighted `directed graphs <https://en.wikipedia.org/wiki/Directed_graph>`_**`` -->> ``**weighted** `directed graphs <https://en.wikipedia.org/wiki/Directed_graph>`_``