### PR TITLE
[05_complex_and_trig] Fix SymPyDepreciationWarning (Issue58 in repo lecture-python.myst)

### DIFF
--- a/source/rst/complex_and_trig.rst
+++ b/source/rst/complex_and_trig.rst
@@ -305,7 +305,7 @@ condition:
     print(f'ω = {ω:1.3f}')
 
     # Solve for p
-    eq2 = Eq(x0 - 2 * p * cos(ω))
+    eq2 = Eq(x0 - 2 * p * cos(ω), 0)
     p = nsolve(eq2, p, 0)
     p = np.float(p)
     print(f'p = {p:1.3f}')


### PR DESCRIPTION
Hi @mmcky and @jstac , as suggested @mmcky , this PR is migrated from repo ``lecture-python.myst`` to fix [issue #58](https://github.com/QuantEcon/lecture-python.myst/issues/58) there by 
- changing code ``eq2 = Eq(x0 - 2 * p * cos(ω))`` to ``eq2 = Eq(x0 - 2 * p * cos(ω), 0)`` in lecture [complex_and_trig](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/complex_and_trig.md).