### PR TITLE
[optgrowth]fix spaces

### DIFF
--- a/source/_static/lecture_specific/optgrowth/cd_analytical.py
+++ b/source/_static/lecture_specific/optgrowth/cd_analytical.py
@@ -1,4 +1,3 @@
-
 def v_star(y, α, β, μ):
     """
     True value function
@@ -14,4 +13,3 @@ def σ_star(y, α, β):
     True optimal policy
     """
     return (1 - α * β) * y
-

--- a/source/_static/lecture_specific/optgrowth_fast/ogm.py
+++ b/source/_static/lecture_specific/optgrowth_fast/ogm.py
@@ -1,4 +1,3 @@
-
 opt_growth_data = [
     ('α', float64),          # Production parameter
     ('β', float64),          # Discount factor
@@ -52,5 +51,3 @@ class OptimalGrowthModel:
     def u_prime_inv(self, c):
         "Inverse of u'"
         return 1/c
-
-

--- a/source/_static/lecture_specific/optgrowth_fast/ogm_crra.py
+++ b/source/_static/lecture_specific/optgrowth_fast/ogm_crra.py
@@ -1,5 +1,3 @@
-
-
 opt_growth_data = [
     ('α', float64),          # Production parameter
     ('β', float64),          # Discount factor
@@ -52,4 +50,3 @@ class OptimalGrowthModel_CRRA:
 
     def u_prime_inv(c):
         return c**(-1 / self.γ)
-


### PR DESCRIPTION
Hi @mmcky ,

This fix [#47](https://github.com/QuantEcon/lecture-python.myst/issues/47).
```ogm.py``` and ```ogm_crra.py``` also have redundant lines which occurs in lecture 31 & 32 as mentioned in the issue.