### PR TITLE
[54_harrison_kreps] fix pessimistic matrix

### DIFF
--- a/source/rst/harrison_kreps.rst
+++ b/source/rst/harrison_kreps.rst
@@ -211,8 +211,8 @@ Temporarily pessimistic believe the transition matrix
 
     P_p =
         \begin{bmatrix}
-            \frac{1}{2} & \frac{1}{2} \\
-            \frac{1}{4} & \frac{3}{4}
+            \frac{2}{3} & \frac{1}{3} \\
+            \frac{2}{3} & \frac{1}{3}
         \end{bmatrix}
 
 We'll return to these matrices and their significance in the exercise.


### PR DESCRIPTION
Hi @mmcky and @jstac , this PR fix issue #251 and part of the issue #226 by
- replacing the pessimistic matrix ``[[1/2, 1/2], [1/4, 3/4]]`` in the contexts with ``[[2/3, 1/3], [2/3, 1/3]]`` (which is used for exercise and can generate the same results in those tables) in lecture [harrison_kreps](https://python.quantecon.org/harrison_kreps.html#Optimism-and-Pessimism).