### PR TITLE
[Math] remove {equation} environments

### DIFF
--- a/source/rst/lq_inventories.rst
+++ b/source/rst/lq_inventories.rst
@@ -126,9 +126,6 @@ time :math:`t` function can be expressed
 
 .. math::
 
-
-   \begin{equation}
-   \begin{split}
    \pi_{t} =&p_{t}S_{t}-c\left(Q_{t}\right)-d\left(I_{t},S_{t}\right)  \\
        =&\left(a_{0}-a_{1}S_{t}+v_{t}\right)S_{t}-c_{1}Q_{t}-c_{2}Q_{t}^{2}-d_{1}I_{t}-d_{2}\left(S_{t}-I_{t}\right)^{2}  \\
        =&a_{0}S_{t}-a_{1}S_{t}^{2}+Gz_{t}S_{t}-c_{1}Q_{t}-c_{2}Q_{t}^{2}-d_{1}I_{t}-d_{2}S_{t}^{2}-d_{2}I_{t}^{2}+2d_{2}S_{t}I_{t}  \\
@@ -156,8 +153,6 @@ time :math:`t` function can be expressed
    I_{t}\\
    z_{t}
    \end{array}\right]\right)
-   \end{split}
-   \end{equation}
 
 where :math:`S_{c}=\left[1,0\right]`.
 

--- a/source/rst/lq_inventories.rst
+++ b/source/rst/lq_inventories.rst
@@ -126,6 +126,7 @@ time :math:`t` function can be expressed
 
 .. math::
 
+   \begin{aligned}
    \pi_{t} =&p_{t}S_{t}-c\left(Q_{t}\right)-d\left(I_{t},S_{t}\right)  \\
        =&\left(a_{0}-a_{1}S_{t}+v_{t}\right)S_{t}-c_{1}Q_{t}-c_{2}Q_{t}^{2}-d_{1}I_{t}-d_{2}\left(S_{t}-I_{t}\right)^{2}  \\
        =&a_{0}S_{t}-a_{1}S_{t}^{2}+Gz_{t}S_{t}-c_{1}Q_{t}-c_{2}Q_{t}^{2}-d_{1}I_{t}-d_{2}S_{t}^{2}-d_{2}I_{t}^{2}+2d_{2}S_{t}I_{t}  \\
@@ -153,6 +154,7 @@ time :math:`t` function can be expressed
    I_{t}\\
    z_{t}
    \end{array}\right]\right)
+   \end{aligned}
 
 where :math:`S_{c}=\left[1,0\right]`.
 


### PR DESCRIPTION
This PR removes an `{equation}` environment within a `math` directive