### PR TITLE
FIX: update link to single line for migration to myst

### DIFF
--- a/source/rst/lake_model.rst
+++ b/source/rst/lake_model.rst
@@ -68,8 +68,8 @@ Let's start with some imports:
 Prerequisites
 -------------
 
-Before working through what follows, we recommend you read the :doc:`lecture
-on finite Markov chains <finite_markov>`.
+Before working through what follows, we recommend you read the
+:doc:`lecture on finite Markov chains <finite_markov>`.
 
 You will also need some basic :doc:`linear algebra <linear_algebra>` and probability.
 


### PR DESCRIPTION
This PR is a minor update for compatibility with `myst`