### PR TITLE
[harrison_kreps] small typo

### DIFF
--- a/source/rst/harrison_kreps.rst
+++ b/source/rst/harrison_kreps.rst
@@ -205,7 +205,7 @@ beliefs in each state) believe the transition matrix
         \end{bmatrix}
 
 
-Temporarily pessimistic believe the transition matrix
+Temporarily pessimistic investors believe the transition matrix
 
 .. math::
 


### PR DESCRIPTION
Hi @jstac , this PR modifes the following sentence in lecture [harrison_kreps](https://python.quantecon.org/harrison_kreps.html#Optimism-and-Pessimism):
- ``Temporarily pessimistic believe the transition matrix`` -->> ``Temporarily pessimistic investors believe the transition matrix``

which fixes the second comments of issue #373 .