### PR TITLE
FIX: revert pip to conda in RST repository (for colab integration)

### DIFF
--- a/source/rst/aiyagari.rst
+++ b/source/rst/aiyagari.rst
@@ -16,7 +16,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ============

--- a/source/rst/career.rst
+++ b/source/rst/career.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ============

--- a/source/rst/coleman_policy_iter.rst
+++ b/source/rst/coleman_policy_iter.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 

--- a/source/rst/egm_policy_iter.rst
+++ b/source/rst/egm_policy_iter.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 Overview

--- a/source/rst/finite_markov.rst
+++ b/source/rst/finite_markov.rst
@@ -15,7 +15,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 =============

--- a/source/rst/harrison_kreps.rst
+++ b/source/rst/harrison_kreps.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture uses following libraries:
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 =========

--- a/source/rst/heavy_tails.rst
+++ b/source/rst/heavy_tails.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install --upgrade yfinance
 
 

--- a/source/rst/ifp.rst
+++ b/source/rst/ifp.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 

--- a/source/rst/ifp_advanced.rst
+++ b/source/rst/ifp_advanced.rst
@@ -13,7 +13,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 

--- a/source/rst/jv.rst
+++ b/source/rst/jv.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 Overview

--- a/source/rst/kalman.rst
+++ b/source/rst/kalman.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
     :class: hide-output
 
-    !conda install -y quantecon
+    !pip install quantecon
 
 Overview
 ========

--- a/source/rst/kesten_processes.rst
+++ b/source/rst/kesten_processes.rst
@@ -16,7 +16,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install --upgrade yfinance
 
 

--- a/source/rst/lake_model.rst
+++ b/source/rst/lake_model.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/linear_models.rst
+++ b/source/rst/linear_models.rst
@@ -22,7 +22,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/lq_inventories.rst
+++ b/source/rst/lq_inventories.rst
@@ -17,7 +17,7 @@ In addition to what's in Anaconda, this lecture employs the following library:
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 
 Overview

--- a/source/rst/lqcontrol.rst
+++ b/source/rst/lqcontrol.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/markov_asset.rst
+++ b/source/rst/markov_asset.rst
@@ -27,7 +27,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 
 Overview

--- a/source/rst/markov_perf.rst
+++ b/source/rst/markov_perf.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/mccall_correlated.rst
+++ b/source/rst/mccall_correlated.rst
@@ -17,7 +17,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 Overview

--- a/source/rst/mccall_fitted_vfi.rst
+++ b/source/rst/mccall_fitted_vfi.rst
@@ -15,7 +15,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 

--- a/source/rst/mccall_model.rst
+++ b/source/rst/mccall_model.rst
@@ -24,7 +24,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/mccall_model_with_separation.rst
+++ b/source/rst/mccall_model_with_separation.rst
@@ -19,7 +19,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 
 

--- a/source/rst/navy_captain.rst
+++ b/source/rst/navy_captain.rst
@@ -15,7 +15,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 
 .. code-block:: ipython

--- a/source/rst/odu.rst
+++ b/source/rst/odu.rst
@@ -16,7 +16,7 @@ In addition to what’s in Anaconda, this lecture deploys the libraries:
 .. code-block:: ipython
   :class: hide-output
 
-    !conda install -y quantecon
+    !pip install quantecon
     !pip install interpolation
 
 Overview

--- a/source/rst/optgrowth_fast.rst
+++ b/source/rst/optgrowth_fast.rst
@@ -16,7 +16,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 Overview

--- a/source/rst/perm_income.rst
+++ b/source/rst/perm_income.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/perm_income_cons.rst
+++ b/source/rst/perm_income_cons.rst
@@ -18,7 +18,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/rational_expectations.rst
+++ b/source/rst/rational_expectations.rst
@@ -17,7 +17,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 Overview
 ========

--- a/source/rst/re_with_feedback.rst
+++ b/source/rst/re_with_feedback.rst
@@ -20,7 +20,7 @@ In addition to what's in Anaconda, this lecture deploys the following libraries:
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 
 .. code-block:: ipython

--- a/source/rst/samuelson.rst
+++ b/source/rst/samuelson.rst
@@ -14,7 +14,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 
 Overview

--- a/source/rst/troubleshooting.rst
+++ b/source/rst/troubleshooting.rst
@@ -37,7 +37,7 @@ For this task you can either
 
 * use `conda install -y quantecon` on the command line, or
 
-* execute `!conda install -y quantecon` within a Jupyter notebook.
+* execute `!pip install quantecon` within a Jupyter notebook.
 
 If your local environment is still not working you can do two things.
 

--- a/source/rst/wald_friedman.rst
+++ b/source/rst/wald_friedman.rst
@@ -22,7 +22,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
   !pip install interpolation
 
 

--- a/source/rst/wealth_dynamics.rst
+++ b/source/rst/wealth_dynamics.rst
@@ -14,7 +14,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 .. code-block:: ipython
   :class: hide-output
 
-  !conda install -y quantecon
+  !pip install quantecon
 
 
 Overview


### PR DESCRIPTION
This PR reverts to `pip` to reinstate compatibility with `colab`. 

**Note:** do not migrate to `lecture-python.myst` as that repository will continue to use `conda`