### PR TITLE
updated iterataion variable

### DIFF
--- a/source/rst/mccall_model.rst
+++ b/source/rst/mccall_model.rst
@@ -461,8 +461,8 @@ Here's a function to implement this:
         for i in range(num_plots):
             ax.plot(mcm.w, v, '-', alpha=0.4, label=f"iterate {i}")
             # Update guess
-            for i in range(n):
-                v_next[i] = np.max(mcm.state_action_values(i, v))
+            for j in range(n):
+                v_next[j] = np.max(mcm.state_action_values(j, v))
             v[:] = v_next  # copy contents into v
 
         ax.legend(loc='lower right')

--- a/source/rst/mccall_model.rst
+++ b/source/rst/mccall_model.rst
@@ -507,8 +507,8 @@ We'll be using JIT compilation via Numba to turbocharge our loops.
         error = tol + 1
         while i < max_iter and error > tol:
 
-            for i in range(n):
-                v_next[i] = np.max(mcm.state_action_values(i, v))
+            for k in range(n):
+                v_next[k] = np.max(mcm.state_action_values(k, v))
 
             error = np.max(np.abs(v_next - v))
             i += 1


### PR DESCRIPTION
It calculates reservation wage correct anyway but because of using the same variable for iteration in a "while" and "for" loop, "max_iter" becomes useless, such that if choosing "max_iter" less than converging iteration number, it again continues to converge at this number of iterations which is higher than "max_iter".  Also in a while loop, an iteration variable prints number of wage points, not consecutive numbers of iteration